### PR TITLE
Add sei registry and amino types by default

### DIFF
--- a/.changeset/gentle-mayflies-accept.md
+++ b/.changeset/gentle-mayflies-accept.md
@@ -1,0 +1,5 @@
+---
+'@sei-js/core': patch
+---
+
+Use sei registry and amino types by default

--- a/packages/core/src/lib/signingClient/cosmWasmClient.ts
+++ b/packages/core/src/lib/signingClient/cosmWasmClient.ts
@@ -6,6 +6,7 @@ import { OfflineSigner } from '@cosmjs/proto-signing';
 
 import { SeiCosmWasmClient, SeiSigningCosmWasmClient } from '../client';
 import { SeiClientOptions, SeiSigningCosmWasmClientOptions } from './types';
+import { createSeiAminoTypes, createSeiRegistry } from './stargateClient';
 
 export const getCosmWasmClient = async (
   rpcEndpoint: string,
@@ -23,17 +24,20 @@ export const getSigningCosmWasmClient = async (
   signer: OfflineSigner,
   options: SeiSigningCosmWasmClientOptions = {}
 ): Promise<SigningCosmWasmClient> => {
+  const registry = createSeiRegistry();
+  const aminoTypes = createSeiAminoTypes();
+
   if (options.useTM34) {
-    return SigningCosmWasmClient.connectWithSigner(
-      rpcEndpoint,
-      signer,
-      options
-    );
+    return SigningCosmWasmClient.connectWithSigner(rpcEndpoint, signer, {
+      registry,
+      aminoTypes,
+      ...options,
+    });
   }
 
-  return SeiSigningCosmWasmClient.connectWithSigner(
-    rpcEndpoint,
-    signer,
-    options
-  );
+  return SeiSigningCosmWasmClient.connectWithSigner(rpcEndpoint, signer, {
+    registry,
+    aminoTypes,
+    ...options,
+  });
 };


### PR DESCRIPTION
Use default sei proto registry and amino types by default for the signing clients

Published to @sei-js/core under the `internal` tag - `0.0.0-internal-20230331005511`