### PR TITLE
Fix CosmWasm registry types

### DIFF
--- a/.changeset/four-ears-hope.md
+++ b/.changeset/four-ears-hope.md
@@ -1,0 +1,5 @@
+---
+'@sei-js/core': patch
+---
+
+Fix registry types for signing cosmwasm clients

--- a/packages/core/src/lib/signingClient/stargateClient.ts
+++ b/packages/core/src/lib/signingClient/stargateClient.ts
@@ -8,6 +8,7 @@ import { OfflineSigner, Registry } from '@cosmjs/proto-signing';
 import {
   cosmosAminoConverters,
   cosmwasmAminoConverters,
+  cosmwasmProtoRegistry,
   ibcAminoConverters,
   seiprotocolProtoRegistry,
   seiprotocolAminoConverters,
@@ -20,7 +21,11 @@ import {
 } from './types';
 
 export const createSeiRegistry = (): Registry => {
-  return new Registry([...defaultRegistryTypes, ...seiprotocolProtoRegistry]);
+  return new Registry([
+    ...defaultRegistryTypes,
+    ...cosmwasmProtoRegistry,
+    ...seiprotocolProtoRegistry,
+  ]);
 };
 
 export const createSeiAminoTypes = (): AminoTypes => {


### PR DESCRIPTION
The default registry types from cosmjs don't include the cosmwasm types, so the current cosmwasm client fails when trying to execute a message:
`Error: Unregistered type url: /cosmwasm.wasm.v1.MsgExecuteContract`