### PR TITLE
Added ability to set input wallets from wallet connect button

### DIFF
--- a/.changeset/moody-eggs-sing.md
+++ b/.changeset/moody-eggs-sing.md
@@ -1,0 +1,5 @@
+---
+'@sei-js/react': minor
+---
+
+Added the ability to set the input wallets that show up when using the WalletConnectButton component

--- a/packages/react/src/lib/components/WalletConnectButton/WalletConnectButton.tsx
+++ b/packages/react/src/lib/components/WalletConnectButton/WalletConnectButton.tsx
@@ -11,6 +11,7 @@ export const truncateAddress = (address: string) =>
 const WalletConnectButton = ({
   buttonStyles,
   buttonClassName,
+  wallets,
 }: WalletConnectButtonProps) => {
   const [showMenu, setShowMenu] = useState<boolean>(false);
   const [recentlyCopied, setRecentlyCopied] = useState<boolean>(false);
@@ -100,6 +101,7 @@ const WalletConnectButton = ({
       {renderButton()}
       {showConnectModal && (
         <WalletSelectModal
+          inputWallets={wallets}
           walletSelectStyles={buttonStyles?.walletSelectStyles}
           setShowConnectModal={setShowConnectModal}
         />

--- a/packages/react/src/lib/components/WalletConnectButton/types.ts
+++ b/packages/react/src/lib/components/WalletConnectButton/types.ts
@@ -1,8 +1,10 @@
 import { CSSProperties } from 'react';
 import { WalletSelectStyles } from '../WalletSelectModal/types';
+import { WalletWindowKey } from '@sei-js/core';
 
 export type WalletConnectButtonProps = {
   buttonClassName?: string;
+  wallets?: WalletWindowKey[];
   buttonStyles?: {
     button?: CSSProperties;
     menu?: CSSProperties;


### PR DESCRIPTION
Can't currently choose the wallets that show up when using the default modal in the WalletConnectButton component.