### PR TITLE
Use getOfflineSignerAuto when connecting wallet

### DIFF
--- a/.changeset/wise-rabbits-cough.md
+++ b/.changeset/wise-rabbits-cough.md
@@ -1,0 +1,5 @@
+---
+'@sei-js/core': patch
+---
+
+Use getOfflineSignerAuto when connecting wallet

--- a/packages/core/src/lib/wallet/connect.spec.ts
+++ b/packages/core/src/lib/wallet/connect.spec.ts
@@ -39,7 +39,7 @@ describe('connect', () => {
     const accounts = await offlineSigner.getAccounts();
     windowSpy.mockImplementation(() => ({
       keplr: {
-        getOfflineSigner: () => offlineSigner,
+        getOfflineSignerAuto: () => offlineSigner,
         experimentalSuggestChain: () => undefined,
         enable: () => undefined,
       },

--- a/packages/core/src/lib/wallet/connect.ts
+++ b/packages/core/src/lib/wallet/connect.ts
@@ -29,7 +29,7 @@ export const connect = async (
   // Enable wallet before attempting to call any methods
   await walletProvider.enable(chainId);
 
-  const offlineSigner = await walletProvider.getOfflineSigner(chainId);
+  const offlineSigner = await walletProvider.getOfflineSignerAuto(chainId);
   const accounts = await offlineSigner.getAccounts();
 
   return { offlineSigner, accounts };


### PR DESCRIPTION
`getOfflineSignerAuto` will return an amino signer for Ledger wallets and a direct signer otherwise. This will allow enable Ledger support. 

Published to @sei-js/core@internal and tested on js-examples