### PR TITLE
Fix: Menu autoclose, disconnect hook, fix signArbitrary

### DIFF
--- a/.changeset/hungry-poets-cross.md
+++ b/.changeset/hungry-poets-cross.md
@@ -1,0 +1,5 @@
+---
+'@sei-js/react': patch
+---
+
+This fixes an issue where the wallet button menu pops up after connecting to a wallet

--- a/.changeset/hungry-poets-cross.md
+++ b/.changeset/hungry-poets-cross.md
@@ -2,4 +2,4 @@
 '@sei-js/react': patch
 ---
 
-This fixes an issue where the wallet button menu pops up after connecting to a wallet
+This fixes an issue where the wallet button menu pops up after connecting to a wallet, Fixes the sign arbitrary function on connected wallets, added an optional disconnect function to the useWallet hook.

--- a/packages/react/src/lib/components/WalletConnectButton/WalletConnectButton.tsx
+++ b/packages/react/src/lib/components/WalletConnectButton/WalletConnectButton.tsx
@@ -35,8 +35,8 @@ const WalletConnectButton = ({ buttonClassName, primaryColor, secondaryColor, ba
 	}, [backgroundColor]);
 
 	const changeWallet = () => {
-		setShowConnectModal(true);
 		setShowMenu(false);
+		setShowConnectModal(true);
 	};
 
 	const copyAddress = async () => {

--- a/packages/react/src/lib/components/WalletSelectModal/WalletSelectModal.tsx
+++ b/packages/react/src/lib/components/WalletSelectModal/WalletSelectModal.tsx
@@ -35,7 +35,6 @@ const WalletSelectModal = ({ wallets: inputWallets }: WalletSelectModalProps) =>
 		};
 
 		const selectWallet = async () => {
-			if (wallet.walletInfo.name === targetWallet?.walletInfo.name) return;
 			if (setTargetWallet) setTargetWallet(wallet);
 			setIsConnecting(true);
 			setConnectionError(undefined);

--- a/packages/react/src/lib/config/supportedWallets.ts
+++ b/packages/react/src/lib/config/supportedWallets.ts
@@ -8,7 +8,7 @@ export const FIN_WALLET: SeiWallet = {
 	connect: async (chainId) => await window?.['fin']?.enable(chainId),
 	disconnect: async (chainId) => await window?.['fin']?.disable(chainId),
 	getOfflineSigner: async (chainId) => window?.['fin']?.getOfflineSignerAuto(chainId),
-	signArbitrary: window?.['fin']?.signArbitrary,
+	signArbitrary: async (chainId, signer, message) => window?.['fin']?.signArbitrary(chainId, signer, message),
 	walletInfo: {
 		windowKey: 'fin',
 		name: 'Fin',
@@ -25,7 +25,7 @@ export const COMPASS_WALLET: SeiWallet = {
 	connect: async (chainId) => await window?.['compass']?.enable(chainId),
 	disconnect: async (chainId) => await window?.['compass']?.disable(chainId),
 	getOfflineSigner: async (chainId) => window?.['compass']?.getOfflineSignerAuto(chainId),
-	signArbitrary: window?.['compass']?.signArbitrary,
+	signArbitrary: async (chainId, signer, message) => window?.['compass']?.signArbitrary(chainId, signer, message),
 	walletInfo: {
 		windowKey: 'compass',
 		name: 'Compass',
@@ -42,7 +42,7 @@ export const KEPLR_WALLET: SeiWallet = {
 	connect: async (chainId) => await window?.['keplr']?.enable(chainId),
 	disconnect: async (chainId) => await window?.['keplr']?.disable(chainId),
 	getOfflineSigner: async (chainId) => window?.['keplr']?.getOfflineSignerAuto(chainId),
-	signArbitrary: window?.['keplr']?.signArbitrary,
+	signArbitrary: async (chainId, signer, message) => window?.['keplr']?.signArbitrary(chainId, signer, message),
 	walletInfo: {
 		windowKey: 'keplr',
 		name: 'Keplr',
@@ -59,7 +59,7 @@ export const LEAP_WALLET: SeiWallet = {
 	connect: async (chainId) => await window?.['leap']?.enable(chainId),
 	disconnect: async (chainId) => await window?.['leap']?.disable(chainId),
 	getOfflineSigner: async (chainId) => window?.['leap']?.getOfflineSignerAuto(chainId),
-	signArbitrary: window?.['leap']?.signArbitrary,
+	signArbitrary: async (chainId, signer, message) => window?.['leap']?.signArbitrary(chainId, signer, message),
 	walletInfo: {
 		windowKey: 'leap',
 		name: 'Leap',

--- a/packages/react/src/lib/hooks/useWallet/useWallet.ts
+++ b/packages/react/src/lib/hooks/useWallet/useWallet.ts
@@ -9,11 +9,12 @@ type UseWallet = {
 	rpcUrl: string;
 	offlineSigner?: OfflineSigner;
 	accounts: readonly AccountData[];
+	disconnect: () => void;
 };
 const useWallet = (): UseWallet => {
-	const { connectedWallet, chainId, restUrl, rpcUrl, offlineSigner, accounts } = useContext(SeiWalletContext);
+	const { connectedWallet, chainId, restUrl, rpcUrl, offlineSigner, accounts, disconnect } = useContext(SeiWalletContext);
 
-	return { connectedWallet, chainId, restUrl, rpcUrl, offlineSigner, accounts };
+	return { connectedWallet, chainId, restUrl, rpcUrl, offlineSigner, accounts, disconnect };
 };
 
 export default useWallet;

--- a/packages/react/src/lib/provider/SeiWalletProvider.tsx
+++ b/packages/react/src/lib/provider/SeiWalletProvider.tsx
@@ -42,6 +42,7 @@ const SeiWalletProvider = ({ children, chainConfiguration, wallets, autoConnect 
 				return;
 			}
 
+			// const enableResponse = await targetWallet.connect(chainConfiguration.chainId);
 			const fetchedOfflineSigner = await targetWallet.getOfflineSigner(chainConfiguration.chainId);
 
 			if (!fetchedOfflineSigner) {

--- a/packages/react/src/lib/provider/SeiWalletProvider.tsx
+++ b/packages/react/src/lib/provider/SeiWalletProvider.tsx
@@ -79,6 +79,9 @@ const SeiWalletProvider = ({ children, chainConfiguration, wallets, autoConnect 
 
 	const disconnect = () => {
 		setTargetWallet(undefined);
+		setOfflineSigner(undefined);
+		setAccounts([]);
+		setConnectedWallet(undefined);
 	};
 
 	const contextValue: WalletProvider = {

--- a/packages/react/src/lib/provider/types.ts
+++ b/packages/react/src/lib/provider/types.ts
@@ -35,7 +35,7 @@ export interface SeiWallet {
 	connect: (chainId: string) => Promise<void>;
 	disconnect: (chainId: string) => Promise<void>;
 	suggestChain?: (chainId: string) => void;
-	signArbitrary?: (chainId: string, signer: string, message: string) => Promise<StdSignature>;
+	signArbitrary?: (chainId: string, signer: string, message: string) => Promise<StdSignature | undefined>;
 }
 
 export type SeiWalletProviderProps = {


### PR DESCRIPTION
-Fixed signArbitrary export
-Added disconnect hook to useWallet
-Fixed WalletConnectButton menu popping up when selecting a wallet after clicking on the change wallet option


```
const { disconnect, connectedWallet } = useWallet();

const signArbitraryResponse = await connectedWallet.signArbitrary('arctic-1', accounts[0].address, "My signed message");

const onClickDisconnect = () => {
  disconnect()
}
```