### PR TITLE
Remove unnecessary global polyfills

### DIFF
--- a/.changeset/no-polyfills-in-core.md
+++ b/.changeset/no-polyfills-in-core.md
@@ -1,0 +1,5 @@
+---
+"@sei-js/core": patch
+---
+
+Remove global `Buffer` and `process` polyfills

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,9 +40,7 @@
 		"readonly-date": "^1.0.0",
 		"sha.js": "^2.4.11",
 		"xstream": "^11.14.0",
-		"elliptic": "^6.5.4",
-		"buffer": "^6.0.3",
-		"process": "^0.11.10"
+		"elliptic": "^6.5.4"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.22.9",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,1 @@
-import * as process from 'process';
-import { Buffer } from 'buffer';
-
-// Polyfill process and buffer for browser
-Object.assign(self, {
-	process,
-	global: self,
-	Buffer
-});
-
 export * from './lib';


### PR DESCRIPTION
Fixes #79 

1. A top-level `self` isn't supported in strict mode, which aligns with your `tsconfig.json` output settings. As a result, importing `@sei-js/core` as a dependency in node/ts-node triggers the `ReferenceError: self is not defined` error.
2. The inclusion of these polyfills seems redundant and counterproductive:
    * The `process` polyfill doesn't seem to be utilized within `@sei-js/core`, making it an unnecessary inclusion.
    * Regarding the `Buffer` polyfill, it would be more appropriate for the responsibility to fall on the bundler. The current setup could interfere with webpack configurations, including mine and perhaps others.