### PR TITLE
Node polyfill hotfix

### DIFF
--- a/.changeset/blue-jeans-lick.md
+++ b/.changeset/blue-jeans-lick.md
@@ -1,0 +1,6 @@
+---
+'@sei-js/react': patch
+'@sei-js/core': patch
+---
+
+Fixed an issue with polyfilling on Node environments be excluding environments that don't have self (non-browser environments)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,14 @@
-import * as process from 'process';
-import { Buffer } from 'buffer';
+// Check if in browser environment
+if (typeof self !== 'undefined') {
+	const process = require('process');
+	const Buffer = require('buffer').Buffer;
 
-// Polyfill process and buffer for browser
-Object.assign(self, {
-	process,
-	global: self,
-	Buffer
-});
+	// Polyfill process and buffer environment variables
+	Object.assign(self, {
+		process,
+		global: self,
+		Buffer
+	});
+}
 
 export * from './lib';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,14 +1,1 @@
-// Check if in browser environment
-if (typeof self !== 'undefined') {
-	const process = require('process');
-	const Buffer = require('buffer').Buffer;
-
-	// Polyfill process and buffer environment variables
-	Object.assign(self, {
-		process,
-		global: self,
-		Buffer
-	});
-}
-
 export * from './lib';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,11 +1,14 @@
-import * as process from 'process';
-import { Buffer } from 'buffer';
+// Check if in browser environment
+if (typeof self !== 'undefined') {
+	const process = require('process');
+	const Buffer = require('buffer').Buffer;
 
-// Polyfill process and buffer for browser
-Object.assign(self, {
-	process,
-	global: self,
-	Buffer
-});
+	// Polyfill process and buffer environment variables
+	Object.assign(self, {
+		process,
+		global: self,
+		Buffer
+	});
+}
 
 export * from './lib';


### PR DESCRIPTION
This PR fixes an issue with node environments by excluding the polyfill if "self" is not defined.

References:
https://github.com/sei-protocol/sei-js/issues/79
https://github.com/sei-protocol/sei-js/pull/81