### PR TITLE
Fix leap and sei wallet disconnect methods

### DIFF
--- a/packages/core/src/lib/wallet/config.ts
+++ b/packages/core/src/lib/wallet/config.ts
@@ -46,7 +46,7 @@ export const COMPASS_WALLET: SeiWallet = {
 		return offlineSigner?.getAccounts() || [];
 	},
 	connect: async (chainId) => await window?.['compass']?.enable(chainId),
-	disconnect: async (chainId) => await window?.['compass']?.disable(chainId),
+	disconnect: async (chainId) => await window?.['compass']?.disconnect(chainId),
 	getOfflineSigner: async (chainId) => window?.['compass']?.getOfflineSignerAuto(chainId),
 	getOfflineSignerAmino: async (chainId) => window?.['compass']?.getOfflineSignerOnlyAmino(chainId),
 	signArbitrary: async (chainId, signer, message) => window?.['compass']?.signArbitrary(chainId, signer, message),
@@ -87,7 +87,7 @@ export const LEAP_WALLET: SeiWallet = {
 		return offlineSigner?.getAccounts() || [];
 	},
 	connect: async (chainId) => await window?.['leap']?.enable(chainId),
-	disconnect: async (chainId) => await window?.['leap']?.disable(chainId),
+	disconnect: async (chainId) => await window?.['leap']?.disconnect(chainId),
 	getOfflineSigner: async (chainId) => window?.['leap']?.getOfflineSignerAuto(chainId),
 	getOfflineSignerAmino: async (chainId) => window?.['leap']?.getOfflineSignerOnlyAmino(chainId),
 	signArbitrary: async (chainId, signer, message) => window?.['leap']?.signArbitrary(chainId, signer, message),


### PR DESCRIPTION
The method to use for disconnecting from the app is `disconnect` instead of `disable.

Compass docs: https://docs.leapwallet.io/cosmos/sei-dapps/connect-to-compass#connect-to-leap-already-present
Leap docs: https://docs.leapwallet.io/cosmos/for-dapps-connect-to-leap/api-reference#disconnect-from-dapp