### PR TITLE
:update polyfill base on globalThis

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,12 +1,12 @@
 // Check if in browser environment
-if (typeof self !== 'undefined') {
+if (typeof window !== 'undefined') {
 	const process = require('process');
 	const Buffer = require('buffer').Buffer;
 
 	// Polyfill process and buffer environment variables
-	Object.assign(self, {
+	Object.assign(globalThis, {
 		process,
-		global: self,
+		global: globalThis,
 		Buffer
 	});
 }


### PR DESCRIPTION
checking browser to add polyfills with 'self' keyword may lead to lots of conflicts with other node modules. 

To prevent this, instead of checking 'self' and assigning, use 'globalThis'

<img width="791" alt="스크린샷 2023-10-15 오후 5 36 40" src="https://github.com/sei-protocol/sei-js/assets/30416914/1ff629d1-7376-41ac-8b6c-65272184240d">
