### PR TITLE
Use read-only access token for nx cloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}

--- a/nx.json
+++ b/nx.json
@@ -6,7 +6,7 @@
 			"runner": "@nrwl/nx-cloud",
 			"options": {
 				"cacheableOperations": ["lint", "test", "e2e"],
-				"accessToken": "ZGQ0Y2Y2YTItNGZlOC00YTYyLTg4NjUtZTU5YWI1ZjNhNWYxfHJlYWQtd3JpdGU="
+				"accessToken": "ZDFlYTBlNTItNmYyMS00Yjc3LWJhNzEtYThhMGJmZjM5ZTdifHJlYWQ="
 			}
 		}
 	},


### PR DESCRIPTION
Restricts access to read-write access token to only publishing on main