### PR TITLE
Added @sei-js/proto to peer dependency

### DIFF
--- a/.github/workflows/deploydocs.yml
+++ b/.github/workflows/deploydocs.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn
 
       - name: Install Peer Dependencies
-        run: yarn add -W viem@2.x wagmi
+        run: yarn add -W viem@2.x wagmi @sei-js/proto
 
       - name: Create Docs
         run: yarn docs


### PR DESCRIPTION
When building the typedocs it fails because the typedocs is built outside of NX, so where other nx commands succeed the docs fails. To get around this I have installed `@sei-js/proto` during docs generation. This won't affect any other packages and is just used for importing types in cosmjs.