### PR TITLE
v2 follow ups: CosmJS signing clients & registry publish action

### DIFF
--- a/.changeset/swift-boats-obey.md
+++ b/.changeset/swift-boats-obey.md
@@ -1,0 +1,5 @@
+---
+"@sei-js/cosmjs": patch
+---
+
+Cosmjs Query Clients: Added default poll timeout interval, allow passing HttpEndpoint to getting signing CosmJS clients

--- a/packages/cosmjs/src/core/signingClient/cosmWasmClient.ts
+++ b/packages/cosmjs/src/core/signingClient/cosmWasmClient.ts
@@ -1,4 +1,4 @@
-import { CosmWasmClient, SigningCosmWasmClient, SigningCosmWasmClientOptions } from '@cosmjs/cosmwasm-stargate';
+import { CosmWasmClient, HttpEndpoint, SigningCosmWasmClient, SigningCosmWasmClientOptions } from '@cosmjs/cosmwasm-stargate';
 import { OfflineSigner } from '@cosmjs/proto-signing';
 import { createSeiAminoTypes, createSeiRegistry } from './stargateClient';
 
@@ -33,7 +33,7 @@ import { createSeiAminoTypes, createSeiRegistry } from './stargateClient';
  * @returns A CosmWasmClient used to interact with the Sei chain.
  * @category Clients
  */
-export const getCosmWasmClient = async (rpcEndpoint: string): Promise<CosmWasmClient> => {
+export const getCosmWasmClient = async (rpcEndpoint: string | HttpEndpoint): Promise<CosmWasmClient> => {
 	return CosmWasmClient.connect(rpcEndpoint);
 };
 
@@ -72,7 +72,7 @@ export const getCosmWasmClient = async (rpcEndpoint: string): Promise<CosmWasmCl
  * @category Clients
  */
 export const getSigningCosmWasmClient = async (
-	rpcEndpoint: string,
+	rpcEndpoint: string | HttpEndpoint,
 	signer: OfflineSigner,
 	options: SigningCosmWasmClientOptions = {}
 ): Promise<SigningCosmWasmClient> => {
@@ -81,6 +81,7 @@ export const getSigningCosmWasmClient = async (
 	return SigningCosmWasmClient.connectWithSigner(rpcEndpoint, signer, {
 		registry,
 		aminoTypes,
+		broadcastPollIntervalMs: options.broadcastPollIntervalMs || 400,
 		...options
 	});
 };

--- a/packages/cosmjs/src/core/signingClient/stargateClient.ts
+++ b/packages/cosmjs/src/core/signingClient/stargateClient.ts
@@ -8,6 +8,7 @@ import {
 	seiprotocolProtoRegistry,
 	seiprotocolAminoConverters
 } from '@sei-js/proto';
+import { HttpEndpoint } from '@cosmjs/cosmwasm-stargate';
 
 /**
  * Creates a Registry object that maps CosmWasm and Sei protobuf type identifiers to their actual implementations.
@@ -115,7 +116,7 @@ export const createSeiAminoTypes = (): AminoTypes => {
  * @returns A StargateClient object used to interact with the Sei chain.
  * @category Clients
  */
-export const getStargateClient = async (rpcEndpoint: string, options: StargateClientOptions = {}): Promise<StargateClient> => {
+export const getStargateClient = async (rpcEndpoint: string | HttpEndpoint, options: StargateClientOptions = {}): Promise<StargateClient> => {
 	return StargateClient.connect(rpcEndpoint, options);
 };
 
@@ -193,7 +194,7 @@ export const getStargateClient = async (rpcEndpoint: string, options: StargateCl
  * @category Clients
  */
 export const getSigningStargateClient = async (
-	rpcEndpoint: string,
+	rpcEndpoint: string | HttpEndpoint,
 	signer: OfflineSigner,
 	options: SigningStargateClientOptions = {}
 ): Promise<SigningStargateClient> => {
@@ -202,6 +203,7 @@ export const getSigningStargateClient = async (
 	return SigningStargateClient.connectWithSigner(rpcEndpoint, signer, {
 		registry,
 		aminoTypes,
+		broadcastPollIntervalMs: options.broadcastPollIntervalMs || 400,
 		...options
 	});
 };


### PR DESCRIPTION
- Added github action when @sei-js/registry NPM package gets updated
- Added default poll timeout interval
- Allow passing HttpEndpoint to getting signing CosmJS clients