### PR TITLE
Fix name of native currency in viem chain config

### DIFF
--- a/.changeset/brave-jobs-join.md
+++ b/.changeset/brave-jobs-join.md
@@ -1,0 +1,5 @@
+---
+"@sei-js/evm": patch
+---
+
+Update name and symbol of Sei viem chain

--- a/packages/evm/src/providers/viem.ts
+++ b/packages/evm/src/providers/viem.ts
@@ -55,9 +55,9 @@ export const ARCTIC_1_VIEM_CHAIN: Chain = {
 	id: SeiChainInfo.devnet.chainId,
 	name: 'arctic-1',
 	nativeCurrency: {
-		name: 'usei',
+		name: 'Sei',
 		decimals: 18,
-		symbol: 'USEI'
+		symbol: 'SEI'
 	},
 	rpcUrls: {
 		default: {
@@ -113,9 +113,9 @@ export const ATLANTIC_2_VIEM_CHAIN: Chain = {
 	id: SeiChainInfo.testnet.chainId,
 	name: 'atlantic-2',
 	nativeCurrency: {
-		name: 'usei',
+		name: 'Sei',
 		decimals: 18,
-		symbol: 'USEI'
+		symbol: 'SEI'
 	},
 	rpcUrls: {
 		default: {


### PR DESCRIPTION
Rename from `usei` to `Sei`. Otherwise, in MetaMask the balances show `USEI` (see screenshot).

<img width="360" alt="image" src="https://github.com/sei-protocol/sei-js/assets/99624770/62d6c0e2-6459-4637-b25e-8e687683ad97">

