### PR TITLE
Rename chains on viem config

### DIFF
--- a/packages/evm/src/providers/viem.ts
+++ b/packages/evm/src/providers/viem.ts
@@ -53,7 +53,7 @@ export const ARCTIC_1_VIEM_CHAIN: Chain = {
 	},
 	fees: undefined,
 	id: SeiChainInfo.devnet.chainId,
-	name: 'arctic-1',
+	name: 'Sei Devnet',
 	nativeCurrency: {
 		name: 'Sei',
 		decimals: 18,
@@ -111,7 +111,7 @@ export const ATLANTIC_2_VIEM_CHAIN: Chain = {
 	},
 	fees: undefined,
 	id: SeiChainInfo.testnet.chainId,
-	name: 'atlantic-2',
+	name: 'Sei Testnet',
 	nativeCurrency: {
 		name: 'Sei',
 		decimals: 18,


### PR DESCRIPTION
Use more descriptive names
* `arctic-1` -> `Sei Devnet`
* `atlantic-2` -> `Sei Testnet`

In wallets like MetaMask this is more descriptive than using the Chain ID (see screenshot)

<img width="325" alt="image" src="https://github.com/sei-protocol/sei-js/assets/99624770/68caae3f-fe6e-4876-aaf5-aabb4ad81744">
