### PR TITLE
Add pacific-1 evm chain config

### DIFF
--- a/.changeset/odd-games-fail.md
+++ b/.changeset/odd-games-fail.md
@@ -1,0 +1,5 @@
+---
+"@sei-js/evm": patch
+---
+
+Add pacific-1 EVM chain config

--- a/packages/evm/src/chainInfo/__tests__/chainInfo.spec.ts
+++ b/packages/evm/src/chainInfo/__tests__/chainInfo.spec.ts
@@ -1,12 +1,12 @@
 // config.test.ts
-import { SeiChainInfo } from '../chainInfo';
+import { SEI_CHAIN_INFO } from '../chainInfo';
 
 describe('arctic-1 tests', () => {
 	test('CHAIN ID should be correct', () => {
-		expect(SeiChainInfo.devnet.chainId).toBe(713715);
+		expect(SEI_CHAIN_INFO.devnet.chainId).toBe(713715);
 	});
 
 	test('EVM RPC should be correct', () => {
-		expect(SeiChainInfo.devnet.defaultRpc).toBe('https://evm-rpc-arctic-1.sei-apis.com');
+		expect(SEI_CHAIN_INFO.devnet.defaultRpc).toBe('https://evm-rpc-arctic-1.sei-apis.com');
 	});
 });

--- a/packages/evm/src/chainInfo/chainInfo.ts
+++ b/packages/evm/src/chainInfo/chainInfo.ts
@@ -2,7 +2,7 @@
  * The static chain information to be used in various wallet providers, tools, and libraries.
  * @category Chain Constants
  */
-export const SeiChainInfo = {
+export const SEI_CHAIN_INFO = {
 	devnet: {
 		chainId: 713715,
 		defaultRpc: 'https://evm-rpc-arctic-1.sei-apis.com'
@@ -10,5 +10,9 @@ export const SeiChainInfo = {
 	testnet: {
 		chainId: 1328,
 		defaultRpc: 'https://evm-rpc-testnet.sei-apis.com/'
+	},
+	mainnet: {
+		chainId: 1329,
+		defaultRpc: 'https://evm-rpc.sei-apis.com/'
 	}
 };

--- a/packages/evm/src/precompiles/address.ts
+++ b/packages/evm/src/precompiles/address.ts
@@ -97,7 +97,7 @@ export const ADDRESS_PRECOMPILE_ADDRESS: `0x${string}` = '0x00000000000000000000
  *
  * @category Cosmos Interoperability
  */
-export const ADDRESS_PRECOMPILE_ABI: Abi = [
+export const ADDRESS_PRECOMPILE_ABI: Abi & InterfaceAbi = [
 	{
 		inputs: [{ internalType: 'string', name: 'addr', type: 'string' }],
 		name: 'getEvmAddr',
@@ -121,7 +121,7 @@ export const ADDRESS_PRECOMPILE_ABI: Abi = [
  * @example
  * ethers v6: Use the `ethers` library and precompiles to read the associated Cosmos address for the connected account.
  * ```tsx
- * import { ADDRESS_PRECOMPILE_ADDRESS } from '@sei-js/evm';
+ * import { getAddressPrecompileEthersV6Contract } from '@sei-js/evm';
  * import { ethers } from 'ethers';
  *
  * const provider = new ethers.BrowserProvider(window.ethereum); // or any other provider
@@ -129,15 +129,14 @@ export const ADDRESS_PRECOMPILE_ABI: Abi = [
  *
  * const accounts = await provider.send('eth_requestAccounts', []);
  *
- * const addressPrecompileContract = getAddressPrecompileEthersV6Contract(ADDRESS_PRECOMPILE_ADDRESS, signer);
+ * const addressPrecompileContract = getAddressPrecompileEthersV6Contract(signer);
  *
  * const associatedSeiAddress = await addressPrecompileContract.connect().getSeiAddr(accounts[0]);
  * ```
- * @param precompileAddress The 0X address of the precompile contract.
  * @param runner a [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
  * @returns The typed contract instance allowing interaction with the ADDRESS precompile contract.
  * @category Cosmos Interoperability
  */
-export function getAddressPrecompileEthersV6Contract(precompileAddress: `0x${string}`, runner: ContractRunner): AddressPrecompileContract {
-	return new ethers.Contract(precompileAddress, ADDRESS_PRECOMPILE_ABI as InterfaceAbi, runner) as AddressPrecompileContract;
+export function getAddressPrecompileEthersV6Contract(runner: ContractRunner): AddressPrecompileContract {
+	return new ethers.Contract(ADDRESS_PRECOMPILE_ADDRESS, ADDRESS_PRECOMPILE_ABI, runner) as AddressPrecompileContract;
 }

--- a/packages/evm/src/precompiles/bank.ts
+++ b/packages/evm/src/precompiles/bank.ts
@@ -150,7 +150,7 @@ export const BANK_PRECOMPILE_ADDRESS: `0x${string}` = '0x00000000000000000000000
  *
  * @category Cosmos Interoperability
  */
-export const BANK_PRECOMPILE_ABI: Abi = [
+export const BANK_PRECOMPILE_ABI: Abi & InterfaceAbi = [
 	{
 		inputs: [{ internalType: 'address', name: 'acc', type: 'address' }],
 		name: 'all_balances',
@@ -232,7 +232,7 @@ export const BANK_PRECOMPILE_ABI: Abi = [
  *
  * @example
  * ```tsx
- * import { BANK_PRECOMPILE_ADDRESS } from '@sei-js/evm';
+ * import { getBankPrecompileEthersV6Contract } from '@sei-js/evm';
  * import { ethers } from 'ethers';
  *
  * const provider = new ethers.BrowserProvider(window.ethereum); // or any other provider
@@ -240,16 +240,15 @@ export const BANK_PRECOMPILE_ABI: Abi = [
  *
  * const accounts = await provider.send('eth_requestAccounts', []);
  *
- * const bankPrecompileContract = getBankPrecompileEthersV6Contract(BANK_PRECOMPILE_ADDRESS, signer);
+ * const bankPrecompileContract = getBankPrecompileEthersV6Contract(signer);
  *
  * const balance = await bankPrecompileContract.balance(accounts[0], 'usei');
  * ```
  *
- * @param precompileAddress The 0X address of the precompile contract.
  * @param runner a [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
  * @returns The typed contract instance allowing interaction with the precompile contract.
  * @category Cosmos Interoperability
  */
-export const getBankPrecompileEthersV6Contract = (precompileAddress: `0x${string}`, runner: ContractRunner): BankPrecompileContract => {
-	return new ethers.Contract(precompileAddress, BANK_PRECOMPILE_ABI as InterfaceAbi, runner) as BankPrecompileContract;
+export const getBankPrecompileEthersV6Contract = (runner: ContractRunner): BankPrecompileContract => {
+	return new ethers.Contract(BANK_PRECOMPILE_ADDRESS, BANK_PRECOMPILE_ABI, runner) as BankPrecompileContract;
 };

--- a/packages/evm/src/precompiles/distribution.ts
+++ b/packages/evm/src/precompiles/distribution.ts
@@ -112,7 +112,7 @@ export const DISTRIBUTION_PRECOMPILE_ADDRESS: `0x${string}` = '0x000000000000000
  *
  * @category Cosmos Interoperability
  */
-export const DISTRIBUTION_PRECOMPILE_ABI: Abi = [
+export const DISTRIBUTION_PRECOMPILE_ABI: Abi & InterfaceAbi = [
 	{
 		inputs: [{ internalType: 'address', name: 'withdrawAddr', type: 'address' }],
 		name: 'setWithdrawAddress',
@@ -135,21 +135,20 @@ export const DISTRIBUTION_PRECOMPILE_ABI: Abi = [
  * @example
  * ethers v6: Use the `ethers` library and precompiles to set the withdrawal address for rewards for the connected account.
  * ```tsx
- * import { getDistributionPrecompileEthersV6Contract, DISTRIBUTION_PRECOMPILE_ADDRESS } from '@sei-js/evm';
+ * import { getDistributionPrecompileEthersV6Contract } from '@sei-js/evm';
  * import { ethers } from 'ethers';
  *
  * const provider = new ethers.BrowserProvider(); // or any other provider
  * const signer = provider.getSigner();
  *
- * const contract = getDistributionPrecompileEthersV6Contract(DISTRIBUTION_PRECOMPILE_ADDRESS, signer);
+ * const contract = getDistributionPrecompileEthersV6Contract(signer);
  *
  * const response = await contract.setWithdrawAddress('0xADDRESS');
  * ```
- * @param precompileAddress The 0X address of the precompile contract.
  * @param runner a [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
  * @returns The typed contract instance allowing interaction with the precompile contract.
  * @category Cosmos Interoperability
  */
-export const getDistributionPrecompileEthersV6Contract = (precompileAddress: `0x${string}`, runner: ContractRunner): DistributionPrecompileContract => {
-	return new ethers.Contract(precompileAddress, DISTRIBUTION_PRECOMPILE_ABI as InterfaceAbi, runner) as DistributionPrecompileContract;
+export const getDistributionPrecompileEthersV6Contract = (runner: ContractRunner): DistributionPrecompileContract => {
+	return new ethers.Contract(DISTRIBUTION_PRECOMPILE_ADDRESS, DISTRIBUTION_PRECOMPILE_ABI, runner) as DistributionPrecompileContract;
 };

--- a/packages/evm/src/precompiles/governance.ts
+++ b/packages/evm/src/precompiles/governance.ts
@@ -95,7 +95,7 @@ export const GOVERNANCE_PRECOMPILE_ADDRESS: `0x${string}` = '0x00000000000000000
  * ```
  * @category Cosmos Interoperability
  * */
-export const GOVERNANCE_PRECOMPILE_ABI: Abi = [
+export const GOVERNANCE_PRECOMPILE_ABI: Abi & InterfaceAbi = [
 	{
 		inputs: [{ internalType: 'uint64', name: 'proposalID', type: 'uint64' }],
 		name: 'deposit',
@@ -121,22 +121,21 @@ export const GOVERNANCE_PRECOMPILE_ABI: Abi = [
  * @example
  * ethers v6
  * ```tsx
- * import { getGovernancePrecompileEthersV6Contract, GOVERNANCE_PRECOMPILE_ADDRESS, parseSei } from '@sei-js/evm';
+ * import { getGovernancePrecompileEthersV6Contract, parseSei } from '@sei-js/evm';
  * import { ethers } from 'ethers';
  *
  * const provider = new ethers.BrowserProvider(); // or any other provider
  * const signer = provider.getSigner();
  *
- * const governancePrecompileContract = getGovernancePrecompileEthersV6Contract(GOVERNANCE_PRECOMPILE_ADDRESS, signer);
+ * const governancePrecompileContract = getGovernancePrecompileEthersV6Contract(signer);
  *
  * //Surround with try/catch for detailed errors
  * const depositResponse = await governancePrecompileContract.connect(signer).deposit('1', { value: parseSei(1) });
  * ```
- * @param precompileAddress The 0X address of the precompile contract.
  * @param runner a [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
  * @returns The typed contract instance allowing interaction with the precompile contract.
  * @category Cosmos Interoperability
  */
-export const getGovernancePrecompileEthersV6Contract = (precompileAddress: `0x${string}`, runner: ContractRunner) => {
-	return new ethers.Contract(precompileAddress, GOVERNANCE_PRECOMPILE_ABI as InterfaceAbi, runner) as GovernancePrecompileContract;
+export const getGovernancePrecompileEthersV6Contract = (runner: ContractRunner) => {
+	return new ethers.Contract(GOVERNANCE_PRECOMPILE_ADDRESS, GOVERNANCE_PRECOMPILE_ABI, runner) as GovernancePrecompileContract;
 };

--- a/packages/evm/src/precompiles/ibc.ts
+++ b/packages/evm/src/precompiles/ibc.ts
@@ -8,33 +8,47 @@ import { Abi } from 'viem';
  */
 export interface IbcPrecompileFunctions {
 	/**
-   * Transfers tokens from the caller's address to another on a different (IBC compatible) chain.
-   * @param toAddress The recipient's address on the other chain
-   * @param port IBC port in source chain (e.g. 'transfer')
-   * @param channel IBC channel in source chain (e.g. 'channel-0')
-   * @param denom The denomination of the tokens to send
-   * @param amount The amount of tokens to send
-   * @param revisionNumber The revision number of the source chain
-   * @param revisionHeight The revision height of the source chain
-   * @param timeoutTimestamp The timeout timestamp of the source chain
-   * @param memo The memo to include in the transaction, if no memo is needed, pass an empty string
-   */
-	transfer(toAddress: string, port: string, channel: string, denom: string, amount: ethers.BigNumberish,
-					 revisionNumber: BigInt, revisionHeight: BigInt, timeoutTimestamp: BigInt, memo: string): Promise<{ success: boolean }>;
+	 * Transfers tokens from the caller's address to another on a different (IBC compatible) chain.
+	 * @param toAddress The recipient's address on the other chain
+	 * @param port IBC port in source chain (e.g. 'transfer')
+	 * @param channel IBC channel in source chain (e.g. 'channel-0')
+	 * @param denom The denomination of the tokens to send
+	 * @param amount The amount of tokens to send
+	 * @param revisionNumber The revision number of the source chain
+	 * @param revisionHeight The revision height of the source chain
+	 * @param timeoutTimestamp The timeout timestamp of the source chain
+	 * @param memo The memo to include in the transaction, if no memo is needed, pass an empty string
+	 */
+	transfer(
+		toAddress: string,
+		port: string,
+		channel: string,
+		denom: string,
+		amount: ethers.BigNumberish,
+		revisionNumber: BigInt,
+		revisionHeight: BigInt,
+		timeoutTimestamp: BigInt,
+		memo: string
+	): Promise<{ success: boolean }>;
 
-  /**
-   * Transfers tokens from the caller's address to another on a different (IBC compatible) chain.
-   * Calculates the timeout height/timestamp based on the current block timestamp.
-   * @param toAddress The recipient's address on the other chain
-   * @param port IBC port in source chain (e.g. 'transfer')
-   * @param channel IBC channel in source chain (e.g. 'channel-0')
-   * @param denom The denomination of the tokens to send
-   * @param amount The amount of tokens to send
-   * @param memo The memo to include in the transaction, if no memo is needed, pass an empty string
-   */
-  transferWithDefaultTimeout(toAddress: string, port: string, channel: string, denom: string,
-                             amount: ethers.BigNumberish, memo: string): Promise<{ success: boolean }>;
-
+	/**
+	 * Transfers tokens from the caller's address to another on a different (IBC compatible) chain.
+	 * Calculates the timeout height/timestamp based on the current block timestamp.
+	 * @param toAddress The recipient's address on the other chain
+	 * @param port IBC port in source chain (e.g. 'transfer')
+	 * @param channel IBC channel in source chain (e.g. 'channel-0')
+	 * @param denom The denomination of the tokens to send
+	 * @param amount The amount of tokens to send
+	 * @param memo The memo to include in the transaction, if no memo is needed, pass an empty string
+	 */
+	transferWithDefaultTimeout(
+		toAddress: string,
+		port: string,
+		channel: string,
+		denom: string,
+		amount: ethers.BigNumberish,
+		memo: string
+	): Promise<{ success: boolean }>;
 }
 
 /**
@@ -103,7 +117,7 @@ export const IBC_PRECOMPILE_ADDRESS: `0x${string}` = '0x000000000000000000000000
  *
  * @category Cosmos Interoperability
  */
-export const IBC_PRECOMPILE_ABI: Abi = [
+export const IBC_PRECOMPILE_ABI: Abi & InterfaceAbi = [
 	{
 		inputs: [
 			{ internalType: 'string', name: 'toAddress', type: 'string' },
@@ -114,28 +128,27 @@ export const IBC_PRECOMPILE_ABI: Abi = [
 			{ internalType: 'uint64', name: 'revisionNumber', type: 'uint64' },
 			{ internalType: 'uint64', name: 'revisionHeight', type: 'uint64' },
 			{ internalType: 'uint64', name: 'timeoutTimestamp', type: 'uint64' },
-      { internalType: 'string', name: 'memo', type: 'string' },
+			{ internalType: 'string', name: 'memo', type: 'string' }
 		],
 		name: 'transfer',
 		outputs: [{ internalType: 'bool', name: 'success', type: 'bool' }],
 		stateMutability: 'payable',
 		type: 'function'
 	},
-  {
-    inputs: [
-      { internalType: 'string', name: 'toAddress', type: 'string' },
-      { internalType: 'string', name: 'port', type: 'string' },
-      { internalType: 'string', name: 'channel', type: 'string' },
-      { internalType: 'string', name: 'denom', type: 'string' },
-      { internalType: 'uint256', name: 'amount', type: 'uint256' },
-      { internalType: 'string', name: 'memo', type: 'string' },
-    ],
-    name: 'transferWithDefaultTimeout',
-    outputs: [{ internalType: 'bool', name: 'success', type: 'bool' }],
-    stateMutability: 'payable',
-    type: 'function'
-  },
-
+	{
+		inputs: [
+			{ internalType: 'string', name: 'toAddress', type: 'string' },
+			{ internalType: 'string', name: 'port', type: 'string' },
+			{ internalType: 'string', name: 'channel', type: 'string' },
+			{ internalType: 'string', name: 'denom', type: 'string' },
+			{ internalType: 'uint256', name: 'amount', type: 'uint256' },
+			{ internalType: 'string', name: 'memo', type: 'string' }
+		],
+		name: 'transferWithDefaultTimeout',
+		outputs: [{ internalType: 'bool', name: 'success', type: 'bool' }],
+		stateMutability: 'payable',
+		type: 'function'
+	}
 ];
 
 /**
@@ -143,23 +156,22 @@ export const IBC_PRECOMPILE_ABI: Abi = [
  *
  * @example
  * ```tsx
- * import { IBC_PRECOMPILE_ADDRESS } from '@sei-js/evm';
+ * import { getIbcPrecompileEthersV6Contract } from '@sei-js/evm';
  * import { ethers } from 'ethers';
  *
  * const provider = new ethers.BrowserProvider(window.ethereum); // or any other provider
  * const signer = await provider.getSigner();
  *
- * const ibcPrecompileContract = getIbcPrecompileEthersV6Contract(IBC_PRECOMPILE_ADDRESS, signer);
+ * const ibcPrecompileContract = getIbcPrecompileEthersV6Contract(signer);
  * const cosmosAddress = 'cosmos1...';
  *
  * const bool = await ibcPrecompileContract.transfer(cosmosAddress, 'transfer', 'channel-0', 'usei', 100, 1n, 1n, 1n, 'memo');
  * ```
  *
- * @param precompileAddress The 0X address of the precompile contract.
  * @param runner a [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
  * @returns The typed contract instance allowing interaction with the precompile contract.
  * @category Cosmos Interoperability
  */
-export const getIbcPrecompileEthersV6Contract = (precompileAddress: `0x${string}`, runner: ContractRunner): IbcPrecompileContract => {
-	return new ethers.Contract(precompileAddress, IBC_PRECOMPILE_ABI as InterfaceAbi, runner) as IbcPrecompileContract;
+export const getIbcPrecompileEthersV6Contract = (runner: ContractRunner): IbcPrecompileContract => {
+	return new ethers.Contract(IBC_PRECOMPILE_ADDRESS, IBC_PRECOMPILE_ABI, runner) as IbcPrecompileContract;
 };

--- a/packages/evm/src/precompiles/json.ts
+++ b/packages/evm/src/precompiles/json.ts
@@ -104,7 +104,7 @@ export const JSON_PRECOMPILE_ADDRESS: `0x${string}` = '0x00000000000000000000000
  *
  * @category Cosmos Interoperability
  */
-export const JSON_PRECOMPILE_ABI: Abi = [
+export const JSON_PRECOMPILE_ABI: Abi & InterfaceAbi = [
 	{
 		inputs: [
 			{ internalType: 'bytes', name: 'input', type: 'bytes' },
@@ -142,7 +142,7 @@ export const JSON_PRECOMPILE_ABI: Abi = [
  *
  * @example
  * ```tsx
- * import { JSON_PRECOMPILE_ADDRESS } from '@sei-js/evm';
+ * import { getJSONPrecompileEthersV6Contract } from '@sei-js/evm';
  * import { ethers } from 'ethers';
  *
  * const provider = new ethers.BrowserProvider(window.ethereum); // or any other provider
@@ -150,15 +150,14 @@ export const JSON_PRECOMPILE_ABI: Abi = [
  *
  * const accounts = await provider.send('eth_requestAccounts', []);
  *
- * const jsonPrecompileContract = getJSONPrecompileEthersV6Contract(JSON_PRECOMPILE_ADDRESS, signer);
+ * const jsonPrecompileContract = getJSONPrecompileEthersV6Contract(signer);
  *
  * const response = await jsonPrecompileContract.connect().extractAsBytes('0xINPUT', 'KEY');
  * ```
- * @param precompileAddress The 0X address of the precompile contract.
  * @param runner a [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
  * @returns The typed contract instance allowing interaction with the precompile contract.
  * @category Cosmos Interoperability
  */
-export const getJSONPrecompileEthersV6Contract = (precompileAddress: `0x${string}`, runner: ContractRunner): JSONPrecompileContract => {
-	return new ethers.Contract(precompileAddress, JSON_PRECOMPILE_ABI as InterfaceAbi, runner) as JSONPrecompileContract;
+export const getJSONPrecompileEthersV6Contract = (runner: ContractRunner): JSONPrecompileContract => {
+	return new ethers.Contract(JSON_PRECOMPILE_ADDRESS, JSON_PRECOMPILE_ABI, runner) as JSONPrecompileContract;
 };

--- a/packages/evm/src/precompiles/oracle.ts
+++ b/packages/evm/src/precompiles/oracle.ts
@@ -117,7 +117,7 @@ export const ORACLE_PRECOMPILE_ADDRESS: `0x${string}` = '0x000000000000000000000
  *
  * @category Cosmos Interoperability
  */
-export const ORACLE_PRECOMPILE_ABI: Abi = [
+export const ORACLE_PRECOMPILE_ABI: Abi & InterfaceAbi = [
 	{
 		inputs: [],
 		name: 'getExchangeRates',
@@ -169,23 +169,22 @@ export const ORACLE_PRECOMPILE_ABI: Abi = [
  *
  * @example
  * ```tsx
- * import { ORACLE_PRECOMPILE_ADDRESS, getOraclePrecompileEthersV6Contract } from '@sei-js/evm';
+ * import { getOraclePrecompileEthersV6Contract } from '@sei-js/evm';
  * import { ethers } from 'ethers';
  *
  * const provider = new ethers.BrowserProvider(window.ethereum); // or any other provider
  * const signer = await provider.getSigner();
  *
- * const oraclePrecompileContract = getOraclePrecompileEthersV6Contract(ORACLE_PRECOMPILE_ADDRESS, signer);
+ * const oraclePrecompileContract = getOraclePrecompileEthersV6Contract(signer);
  *
  * const exchangeRates = await oraclePrecompileContract.getExchangeRates();
  * console.log(exchangeRates);
  * ```
  *
- * @param precompileAddress The 0X address of the precompile contract.
  * @param runner a [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
  * @returns The typed contract instance allowing interaction with the precompile contract.
  * @category Cosmos Interoperability
  */
-export const getOraclePrecompileEthersV6Contract = (precompileAddress: `0x${string}`, runner: ContractRunner): OraclePrecompileContract => {
-	return new ethers.Contract(precompileAddress, ORACLE_PRECOMPILE_ABI as InterfaceAbi, runner) as OraclePrecompileContract;
+export const getOraclePrecompileEthersV6Contract = (runner: ContractRunner): OraclePrecompileContract => {
+	return new ethers.Contract(ORACLE_PRECOMPILE_ADDRESS, ORACLE_PRECOMPILE_ABI, runner) as OraclePrecompileContract;
 };

--- a/packages/evm/src/precompiles/pointer.ts
+++ b/packages/evm/src/precompiles/pointer.ts
@@ -115,7 +115,7 @@ export const POINTER_PRECOMPILE_ADDRESS: `0x${string}` = '0x00000000000000000000
  *
  * @category Cosmos Interoperability
  */
-export const POINTER_PRECOMPILE_ABI: Abi = [
+export const POINTER_PRECOMPILE_ABI: Abi & InterfaceAbi = [
 	{
 		inputs: [{ internalType: 'string', name: 'cwAddr', type: 'string' }],
 		name: 'addCW20Pointer',
@@ -144,23 +144,22 @@ export const POINTER_PRECOMPILE_ABI: Abi = [
  *
  * @example
  * ```tsx
- * import { POINTER_PRECOMPILE_ADDRESS, getPointerPrecompileEthersV6Contract } from '@sei-js/evm';
+ * import { getPointerPrecompileEthersV6Contract } from '@sei-js/evm';
  * import { ethers } from 'ethers';
  *
  * const provider = new ethers.BrowserProvider(window.ethereum); // or any other provider
  * const signer = await provider.getSigner();
  *
- * const pointerPrecompileContract = getPointerPrecompileEthersV6Contract(POINTER_PRECOMPILE_ADDRESS, signer);
+ * const pointerPrecompileContract = getPointerPrecompileEthersV6Contract(signer);
  *
  * const tx = await pointerPrecompileContract.addCW20Pointer('CW20_CONTRACT_ADDRESS', { value: ethers.utils.parseEther('0.01') });
  * console.log(tx);
  * ```
  *
- * @param precompileAddress The 0X address of the precompile contract.
  * @param runner a [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
  * @returns The typed contract instance allowing interaction with the precompile contract.
  * @category Cosmos Interoperability
  */
-export const getPointerPrecompileEthersV6Contract = (precompileAddress: `0x${string}`, runner: ContractRunner): PointerPrecompileContract => {
-	return new ethers.Contract(precompileAddress, POINTER_PRECOMPILE_ABI as InterfaceAbi, runner) as PointerPrecompileContract;
+export const getPointerPrecompileEthersV6Contract = (runner: ContractRunner): PointerPrecompileContract => {
+	return new ethers.Contract(POINTER_PRECOMPILE_ADDRESS, POINTER_PRECOMPILE_ABI, runner) as PointerPrecompileContract;
 };

--- a/packages/evm/src/precompiles/pointerview.ts
+++ b/packages/evm/src/precompiles/pointerview.ts
@@ -113,7 +113,7 @@ export const POINTERVIEW_PRECOMPILE_ADDRESS: `0x${string}` = '0x0000000000000000
  *
  * @category Cosmos Interoperability
  */
-export const POINTERVIEW_PRECOMPILE_ABI: Abi = [
+export const POINTERVIEW_PRECOMPILE_ABI: Abi & InterfaceAbi = [
 	{
 		inputs: [{ internalType: 'string', name: 'cwAddr', type: 'string' }],
 		name: 'getCW20Pointer',
@@ -154,23 +154,22 @@ export const POINTERVIEW_PRECOMPILE_ABI: Abi = [
  *
  * @example
  * ```tsx
- * import { POINTERVIEW_PRECOMPILE_ADDRESS, getPointerviewPrecompileEthersV6Contract } from '@sei-js/evm';
+ * import { getPointerviewPrecompileEthersV6Contract } from '@sei-js/evm';
  * import { ethers } from 'ethers';
  *
  * const provider = new ethers.BrowserProvider(window.ethereum); // or any other provider
  * const signer = await provider.getSigner();
  *
- * const pointerviewPrecompileContract = getPointerviewPrecompileEthersV6Contract(POINTERVIEW_PRECOMPILE_ADDRESS, signer);
+ * const pointerviewPrecompileContract = getPointerviewPrecompileEthersV6Contract(signer);
  *
  * const pointer = await pointerviewPrecompileContract.getCW20Pointer('CW20_CONTRACT_ADDRESS');
  * console.log(pointer);
  * ```
  *
- * @param precompileAddress The 0X address of the precompile contract.
  * @param runner a [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
  * @returns The typed contract instance allowing interaction with the precompile contract.
  * @category Cosmos Interoperability
  */
-export const getPointerviewPrecompileEthersV6Contract = (precompileAddress: `0x${string}`, runner: ContractRunner): PointerviewPrecompileContract => {
-	return new ethers.Contract(precompileAddress, POINTERVIEW_PRECOMPILE_ABI as InterfaceAbi, runner) as PointerviewPrecompileContract;
+export const getPointerviewPrecompileEthersV6Contract = (runner: ContractRunner): PointerviewPrecompileContract => {
+	return new ethers.Contract(POINTERVIEW_PRECOMPILE_ADDRESS, POINTERVIEW_PRECOMPILE_ABI, runner) as PointerviewPrecompileContract;
 };

--- a/packages/evm/src/precompiles/staking.ts
+++ b/packages/evm/src/precompiles/staking.ts
@@ -122,7 +122,7 @@ export const STAKING_PRECOMPILE_ADDRESS: `0x${string}` = '0x00000000000000000000
  * ```
  * @category Cosmos Interoperability
  */
-export const STAKING_PRECOMPILE_ABI: Abi = [
+export const STAKING_PRECOMPILE_ABI: Abi & InterfaceAbi = [
 	{
 		inputs: [{ internalType: 'string', name: 'valAddress', type: 'string' }],
 		name: 'delegate',
@@ -158,7 +158,7 @@ export const STAKING_PRECOMPILE_ABI: Abi = [
  *
  * @example
  * ```tsx
- * import { STAKING_PRECOMPILE_ADDRESS, parseSei } from '@sei-js/evm';
+ * import { getStakingPrecompileEthersV6Contract, parseSei } from '@sei-js/evm';
  * import { ethers } from 'ethers';
  *
  * const provider = new ethers.BrowserProvider(window.ethereum); // or any other provider
@@ -166,15 +166,14 @@ export const STAKING_PRECOMPILE_ABI: Abi = [
  *
  * const accounts = await provider.send('eth_requestAccounts', []);
 
- * const contract = getStakingPrecompileEthersV6Contract(STAKING_PRECOMPILE_ADDRESS, signer);
+ * const contract = getStakingPrecompileEthersV6Contract(signer);
  *
  * const response = await contract.connect().delegate('0xVALIDATOR_ADDRESS', parseSei(1));
  * ```
- * @param precompileAddress The 0X address of the precompile contract.
  * @param runner a [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
  * @returns The typed contract instance allowing interaction with the precompile contract.
  * @category Cosmos Interoperability
  */
-export const getStakingPrecompileEthersV6Contract = (precompileAddress: `0x${string}`, runner: ContractRunner): StakingPrecompileContract => {
-	return new ethers.Contract(precompileAddress, STAKING_PRECOMPILE_ABI as InterfaceAbi, runner) as StakingPrecompileContract;
+export const getStakingPrecompileEthersV6Contract = (runner: ContractRunner): StakingPrecompileContract => {
+	return new ethers.Contract(STAKING_PRECOMPILE_ADDRESS, STAKING_PRECOMPILE_ABI, runner) as StakingPrecompileContract;
 };

--- a/packages/evm/src/precompiles/wasm.ts
+++ b/packages/evm/src/precompiles/wasm.ts
@@ -99,7 +99,7 @@ export const WASM_PRECOMPILE_ADDRESS: `0x${string}` = '0x00000000000000000000000
  *
  * @category Cosmos Interoperability
  */
-export const WASM_PRECOMPILE_ABI: Abi = [
+export const WASM_PRECOMPILE_ABI: Abi & InterfaceAbi = [
 	{
 		inputs: [
 			{ internalType: 'string', name: 'contractAddress', type: 'string' },
@@ -163,22 +163,21 @@ export const WASM_PRECOMPILE_ABI: Abi = [
  * @example
  * ethers v6: Use the `ethers` library and precompiles to read the associated Cosmos address for the connected account.
  * ```tsx
- * import { WASM_PRECOMPILE_ADDRESS } from '@sei-js/evm';
+ * import { getWasmPrecompileEthersV6Contract } from '@sei-js/evm';
  * import { ethers } from 'ethers';
  *
  * const provider = new ethers.BrowserProvider(window.ethereum); // or any other provider
  * const signer = await provider.getSigner();
  *
- * const wasmPrecompileContract = getWasmPrecompileEthersV6Contract(WASM_PRECOMPILE_ADDRESS, signer);
+ * const wasmPrecompileContract = getWasmPrecompileEthersV6Contract(signer);
  *
  * const queryResponse = await addressPrecompileContract.connect().query(CONTRACT_ADDRESS, REQUEST);
  * ```
  *
- * @param precompileAddress The 0X address of the precompile contract.
  * @param runner a [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
  * @returns The typed contract instance allowing interaction with the precompile contract.
  * @category Cosmos Interoperability
  */
-export const getWasmPrecompileEthersV6Contract = (precompileAddress: `0x${string}`, runner: ContractRunner) => {
-	return new ethers.Contract(precompileAddress, WASM_PRECOMPILE_ABI as InterfaceAbi, runner) as WasmPrecompileContract;
+export const getWasmPrecompileEthersV6Contract = (runner: ContractRunner) => {
+	return new ethers.Contract(WASM_PRECOMPILE_ADDRESS, WASM_PRECOMPILE_ABI, runner) as WasmPrecompileContract;
 };

--- a/packages/evm/src/providers/viem.ts
+++ b/packages/evm/src/providers/viem.ts
@@ -1,5 +1,5 @@
 import { Chain } from 'viem';
-import { SeiChainInfo } from '../chainInfo';
+import { SEI_CHAIN_INFO } from '../chainInfo';
 import {
 	ADDRESS_PRECOMPILE_ADDRESS,
 	BANK_PRECOMPILE_ADDRESS,
@@ -8,7 +8,7 @@ import {
 	JSON_PRECOMPILE_ADDRESS,
 	STAKING_PRECOMPILE_ADDRESS,
 	WASM_PRECOMPILE_ADDRESS,
-  IBC_PRECOMPILE_ADDRESS
+	IBC_PRECOMPILE_ADDRESS
 } from '../precompiles';
 
 /**
@@ -37,7 +37,7 @@ import {
 export const ARCTIC_1_VIEM_CHAIN: Chain = {
 	blockExplorers: {
 		default: {
-			name: 'SeiTrace',
+			name: 'Seitrace',
 			url: 'https://seitrace.com'
 		}
 	},
@@ -52,7 +52,7 @@ export const ARCTIC_1_VIEM_CHAIN: Chain = {
 		ibcPrecompile: { address: IBC_PRECOMPILE_ADDRESS }
 	},
 	fees: undefined,
-	id: SeiChainInfo.devnet.chainId,
+	id: SEI_CHAIN_INFO.devnet.chainId,
 	name: 'Sei Devnet',
 	nativeCurrency: {
 		name: 'Sei',
@@ -61,10 +61,10 @@ export const ARCTIC_1_VIEM_CHAIN: Chain = {
 	},
 	rpcUrls: {
 		default: {
-			http: [SeiChainInfo.devnet.defaultRpc]
+			http: [SEI_CHAIN_INFO.devnet.defaultRpc]
 		}
 	},
-	sourceId: SeiChainInfo.devnet.chainId,
+	sourceId: SEI_CHAIN_INFO.devnet.chainId,
 	testnet: true
 };
 
@@ -94,7 +94,7 @@ export const ARCTIC_1_VIEM_CHAIN: Chain = {
 export const ATLANTIC_2_VIEM_CHAIN: Chain = {
 	blockExplorers: {
 		default: {
-			name: 'SeiTrace',
+			name: 'Seitrace',
 			url: 'https://seitrace.com'
 		}
 	},
@@ -110,7 +110,7 @@ export const ATLANTIC_2_VIEM_CHAIN: Chain = {
 		ibcPrecompile: { address: IBC_PRECOMPILE_ADDRESS }
 	},
 	fees: undefined,
-	id: SeiChainInfo.testnet.chainId,
+	id: SEI_CHAIN_INFO.testnet.chainId,
 	name: 'Sei Testnet',
 	nativeCurrency: {
 		name: 'Sei',
@@ -119,9 +119,66 @@ export const ATLANTIC_2_VIEM_CHAIN: Chain = {
 	},
 	rpcUrls: {
 		default: {
-			http: [SeiChainInfo.testnet.defaultRpc]
+			http: [SEI_CHAIN_INFO.testnet.defaultRpc]
 		}
 	},
-	sourceId: SeiChainInfo.testnet.chainId,
+	sourceId: SEI_CHAIN_INFO.testnet.chainId,
+	testnet: true
+};
+
+/**
+ * Creates and returns a Viem Chain with the default pacific-1 configs and precompile contracts added.
+ * @example
+ * React: Use with `createWagmiConfig` for use in a WagmiProvider:
+ * ```tsx
+ * import { ReactNode } from 'react';
+ * import { WagmiProvider } from 'wagmi';
+ * import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+ * import { PACIFIC_1_VIEM_CHAIN, createWagmiConfig } from '@sei-js/evm';
+ *
+ * const queryClient = new QueryClient();
+ *
+ * export const WalletProvider = ({ children }: { children: ReactNode }) => {
+ *  return (
+ *    <WagmiProvider config={createWagmiConfig(PACIFIC_1_VIEM_CHAIN)}>
+ *      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+ *    </WagmiProvider>
+ *  );
+ * };
+ * ```
+ * @returns A 'viem' package chain compatible with Wagmi and Viem.
+ * @category Viem
+ */
+export const PACIFIC_1_VIEM_CHAIN: Chain = {
+	blockExplorers: {
+		default: {
+			name: 'Seitrace',
+			url: 'https://seitrace.com'
+		}
+	},
+	contracts: {
+		addressPrecompile: { address: ADDRESS_PRECOMPILE_ADDRESS },
+		bankPrecompile: { address: BANK_PRECOMPILE_ADDRESS },
+		distributionPrecompile: { address: DISTRIBUTION_PRECOMPILE_ADDRESS },
+		governancePrecompile: { address: GOVERNANCE_PRECOMPILE_ADDRESS },
+		jsonPrecompile: { address: JSON_PRECOMPILE_ADDRESS },
+		stakingPrecompile: { address: STAKING_PRECOMPILE_ADDRESS },
+		wasmPrecompile: { address: WASM_PRECOMPILE_ADDRESS },
+		ibcPrecompile: { address: IBC_PRECOMPILE_ADDRESS }
+	},
+	fees: undefined,
+	id: SEI_CHAIN_INFO.mainnet.chainId,
+	name: 'Sei',
+	nativeCurrency: {
+		name: 'Sei',
+		decimals: 18,
+		symbol: 'SEI'
+	},
+	rpcUrls: {
+		default: {
+			http: [SEI_CHAIN_INFO.mainnet.defaultRpc]
+		}
+	},
+	sourceId: SEI_CHAIN_INFO.mainnet.chainId,
 	testnet: true
 };

--- a/packages/evm/src/providers/wagmi.ts
+++ b/packages/evm/src/providers/wagmi.ts
@@ -32,18 +32,6 @@ export const getBaseSeiWagmiConfig = (chains: [Chain], additionalConnectors: Cre
 		client({ chain }) {
 			return createClient({ chain, transport: http() });
 		},
-		connectors: [
-			...additionalConnectors,
-			injected({ target: 'metaMask' }),
-			// TODO: Add fin here
-			injected({
-				target: {
-					id: 'compassWalletProvider',
-					name: 'Compass',
-					provider: window['compassEvm'],
-					icon: 'https://lh3.googleusercontent.com/zMrH9Wrqlv5BG0w28woqEnopKhXBdSvpLhs-nHYft9BcAvseloVTZDfTJu97cGjWVFUKZ4dM12Y-lyvipJOlcbcAtQ=s120'
-				}
-			})
-		]
+		connectors: [...additionalConnectors, injected({ target: 'metaMask' })]
 	});
 };


### PR DESCRIPTION
- Added pacific-1 evm chain config
- Renamed some variables to make it consistent
- Removed precompile contract addresses from ethers helpers because they're constant across chains
- Merge abi types for ethers and wagmi
- refactored wallets and removed compass and fin until they go live on pacific-1

TODO: Still need to update the rpcs to use the wallet ones