### PR TITLE
Add Associate methods to Addr Precompile

### DIFF
--- a/.changeset/dry-parents-provide.md
+++ b/.changeset/dry-parents-provide.md
@@ -1,0 +1,5 @@
+---
+"@sei-js/evm": patch
+---
+
+Update addr precompiles

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -111,6 +111,9 @@ The Address precompile contract enables the retrieval of associated EVM addresse
 |----------------------------------------------------------------------------------------|-------------------|------------------------|------------------------------------------------------------------|
 | [`getEvmAddr`](/sei-js/docs/interfaces/evm.AddressPrecompileFunctions.html#getEvmAddr) | `addr: ` `string` | `{ response: string }` | Retrieves the associated EVM address for a given Cosmos address. |
 | [`getSeiAddr`](/sei-js/docs/interfaces/evm.AddressPrecompileFunctions.html#getSeiAddr) | `addr: ` `string` | `{ response: string }` | Retrieves the associated Cosmos address for a given EVM address. |
+| [`associate`](/sei-js/docs/interfaces/evm.AddressPrecompileFunctions.html#associate)   | `v: ` `string`, `r: ` `string`, `s: ` `string`, `customMessage: ` `string` | `{ response: string }` | Associates an EVM address with it's corresponding Cosmos address on chain using a signature. |
+| [`associatePubKey`](/sei-js/docs/interfaces/evm.AddressPrecompileFunctions.html#associatePubKey)   | `pubKeyHex: ` `string` | `{ response: string }` | Associates an EVM address with it's corresponding Cosmos address on chain using the Hex-Encoded compressed pubkey (excluding the '0x'). |
+
 
 #### Precompile Address
 0x0000000000000000000000000000000000001004

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -111,7 +111,7 @@ The Address precompile contract enables the retrieval of associated EVM addresse
 |----------------------------------------------------------------------------------------|-------------------|------------------------|------------------------------------------------------------------|
 | [`getEvmAddr`](/sei-js/docs/interfaces/evm.AddressPrecompileFunctions.html#getEvmAddr) | `addr: ` `string` | `{ response: string }` | Retrieves the associated EVM address for a given Cosmos address. |
 | [`getSeiAddr`](/sei-js/docs/interfaces/evm.AddressPrecompileFunctions.html#getSeiAddr) | `addr: ` `string` | `{ response: string }` | Retrieves the associated Cosmos address for a given EVM address. |
-| [`associate`](/sei-js/docs/interfaces/evm.AddressPrecompileFunctions.html#associate)   | `v: ` `string`, `r: ` `string`, `s: ` `string`, `customMessage: ` `string` | `{ response: string }` | Associates an EVM address with it's corresponding Cosmos address on chain using a signature. |
+| [`associate`](/sei-js/docs/interfaces/evm.AddressPrecompileFunctions.html#associate)   | `v: ` `string`, `r: ` `string`, `s: ` `string`, `customMessage: ` `string` | `{ response: string }` | Associates an EVM address with it's corresponding Sei Native address on chain using a signature. |
 | [`associatePubKey`](/sei-js/docs/interfaces/evm.AddressPrecompileFunctions.html#associatePubKey)   | `pubKeyHex: ` `string` | `{ response: string }` | Associates an EVM address with it's corresponding Cosmos address on chain using the Hex-Encoded compressed pubkey (excluding the '0x'). |
 
 

--- a/packages/evm/src/precompiles/address.ts
+++ b/packages/evm/src/precompiles/address.ts
@@ -23,5 +23,19 @@ export const ADDRESS_PRECOMPILE_ABI = [
 		outputs: [{ internalType: 'string', name: 'response', type: 'string' }],
 		stateMutability: 'view',
 		type: 'function'
-	}
+	},
+	{
+		inputs: [{ internalType: 'string', name: 'v', type: 'string' }, { internalType: 'string', name: 'r', type: 'string' }, { internalType: 'string', name: 's', type: 'string' }, { internalType: 'string', name: 'customMessage', type: 'string' }],
+		name: 'associate',
+		outputs: [{ internalType: 'string', name: 'seiAddr', type: 'string' }, { internalType: 'address', name: 'evmAddr', type: 'address' }],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [{ internalType: 'string', name: 'pubKeyHex', type: 'string' }],
+		name: 'associatePubKey',
+		outputs: [{ internalType: 'string', name: 'seiAddr', type: 'string' }, { internalType: 'address', name: 'evmAddr', type: 'address' }],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
 ] as const;


### PR DESCRIPTION
We added new Precompile methods for association using a signature and association using a pubkey.

This PR updates the sei-js addr precompile to support the new association methods.