### PR TITLE
@sei-js/cosmjs: Address & Private Key Derivation Changes

### DIFF
--- a/.changeset/six-cougars-prove.md
+++ b/.changeset/six-cougars-prove.md
@@ -1,0 +1,5 @@
+---
+"@sei-js/cosmjs": patch
+---
+
+Adds a helper function for deriving an address from a given private key

--- a/packages/cosmjs/README.md
+++ b/packages/cosmjs/README.md
@@ -12,6 +12,7 @@ The `@sei-js/cosmjs` package contains helper functions for wallet connection, tr
 - [Signing Client](#signing-client)
 - [Utils](#utils)
   - [Address](#address)
+    - [`deriveAddressesFromPrivateKey`](#pubkeytokeypair)
     - [`pubKeyToKeyPair`](#pubkeytokeypair)
     - [`pubKeyToBytes`](#pubkeytobytes)
     - [`compressedPubKeyToAddress`](#compressedpubkeytoaddress)
@@ -163,6 +164,21 @@ const signingClient = await getSigningStargateClient(RPC_URL, offlineSigner, { r
 ## Utils
 
 ### Address
+
+#### `deriveAddressesFromPrivateKey`
+Derives and returns an address for the given private key.
+
+- **Parameters:**
+  - `privateKeyHex` (`0x{string}`): A hex-encoded private key string.
+
+- **Returns:** `stringr` - An address from the given private key.
+
+- **Usage:**
+```tsx
+import { deriveAddressesFromPrivateKey } from '@sei-js/cosmjs';
+
+const seiAddress = deriveAddressesFromPrivateKey(PRIVATE_KEY);
+```
 
 #### `pubKeyToKeyPair`
 Creates a hex-encoded ECC KeyPair given a public key.

--- a/packages/cosmjs/README.md
+++ b/packages/cosmjs/README.md
@@ -64,17 +64,18 @@ If you prefer to manage wallet connections manually, you can use the native inte
 ### Generating or Restoring a Wallet
 In some circumstances it is necessary to generate a new wallet or to restore a wallet from a given seed phrase.
 ```tsx
-import { generateWallet, restoreWallet } from "@sei-js/cosmjs";
+import { getHdPath, generateWallet, restoreWallet } from "@sei-js/cosmjs";
+
+const cosmosHdPath = getHdPath(0, 118); // This is the default path for Sei wallets account index 0
+const evmHdPath = getHdPath(0, 60); // This is the default path for EVM wallets account index 0
 
 // 12 word mnemonic by default
-const generatedWallet = await generateWallet();
+const generatedWallet = await generateWallet(24, cosmosHdPath);
 console.log('generated mnemonic', generatedWallet.mnemonic);
 
-// or restore a wallet given a seed phrase
-const restoredWallet = await restoreWallet(SEED_PHRASE);
+// or restore a wallet given a seed phrase and coin type 60 HD path
+const restoredWallet = await restoreWallet(SEED_PHRASE, evmHdPath);
 console.log('restored mnemonic', restoredWallet.mnemonic);
-
-//Both the above functions have optional parameters for selecting a certain account index in a given wallet
 ```
 
 ### Cosmos Kit

--- a/packages/cosmjs/src/utils/address.ts
+++ b/packages/cosmjs/src/utils/address.ts
@@ -3,6 +3,23 @@ import { sha256 } from './hash';
 import { ripemd160 } from '@cosmjs/crypto';
 import { toBech32 } from './bech32';
 import { fromBech32 } from '@cosmjs/encoding';
+import { secp256k1 } from '@noble/curves/secp256k1';
+
+/**
+ * Derives and returns the address from a given private key.
+ * @param privateKeyHex A hex (0x) string of the private key of an account.
+ * @returns The corresponding address for the given private key.
+ * @category Utils
+ */
+export const deriveAddressesFromPrivateKey = (privateKeyHex: string) => {
+	const privateKey = Uint8Array.from(Buffer.from(privateKeyHex.padStart(64, '0'), 'hex'));
+	if (privateKey.length !== 32) {
+		throw new Error('Private key must be 32 bytes long.');
+	}
+
+	const publicKey = secp256k1.getPublicKey(privateKey, true);
+	return compressedPubKeyToAddress(publicKey);
+};
 
 /**
  * Creates a hex encoded ECC KeyPair given a public key.

--- a/packages/cosmjs/src/wallet/__tests__/wallet.spec.ts
+++ b/packages/cosmjs/src/wallet/__tests__/wallet.spec.ts
@@ -41,7 +41,7 @@ describe('Wallet functions', () => {
 		const mockWallet = {};
 		(DirectSecp256k1HdWallet.generate as jest.Mock).mockResolvedValue(mockWallet);
 
-		const wallet = await generateWallet(12, 0);
+		const wallet = await generateWallet(12, getHdPath(0));
 
 		expect(wallet).toBe(mockWallet);
 		expect(DirectSecp256k1HdWallet.generate).toHaveBeenCalledWith(12, {
@@ -54,7 +54,7 @@ describe('Wallet functions', () => {
 		const mockWallet = {};
 		(DirectSecp256k1HdWallet.generate as jest.Mock).mockResolvedValue(mockWallet);
 
-		const wallet = await generateWallet(12, 7);
+		const wallet = await generateWallet(12, getHdPath(7));
 
 		expect(wallet).toBe(mockWallet);
 		expect(DirectSecp256k1HdWallet.generate).toHaveBeenCalledWith(12, {
@@ -69,7 +69,7 @@ describe('Wallet functions', () => {
 
 		(DirectSecp256k1HdWallet.fromMnemonic as jest.Mock).mockResolvedValue(mockWallet);
 
-		const wallet = await restoreWallet(seedPhrase, 0);
+		const wallet = await restoreWallet(seedPhrase, getHdPath(0));
 
 		expect(wallet).toBe(mockWallet);
 		expect(DirectSecp256k1HdWallet.fromMnemonic).toHaveBeenCalledWith(seedPhrase, {

--- a/packages/cosmjs/src/wallet/wallet.ts
+++ b/packages/cosmjs/src/wallet/wallet.ts
@@ -4,16 +4,17 @@ import { HdPath, stringToPath } from '@cosmjs/crypto';
 /**
  * Gets the Hierarchical deterministic Cosmos Hub/Atom path for the accountIndex
  * @param accountIndex The account index
+ * @param coinType The coin type to use when deriving the path (118 for Cosmos, 60 for EVM)
  * @returns A HdPath object
  * @category Wallets (Advanced)
  */
-export const getHdPath = (accountIndex = 0): HdPath => {
-	const stringPath = `m/44'/118'/0'/0/${accountIndex}`;
+export const getHdPath = (accountIndex = 0, coinType = 118): HdPath => {
+	const stringPath = `m/44'/${coinType}'/0'/0/${accountIndex}`;
 	return stringToPath(stringPath);
 };
 
 /**
- * Creates a DirectSecp256K1HdWallet object given the account index.
+ * Creates a DirectSecp256K1HdWallet object given an HD path (see #getHDPath).
  *
  * @example
  * ```tsx
@@ -25,19 +26,19 @@ export const getHdPath = (accountIndex = 0): HdPath => {
  * ```
  *
  * @param mnemonicLength The length of the mnemonic phrase to generate with the wallet.
- * @param accountIndex The account index.
+ * @param hdPath hdPath for the wallet you want to generate.
  * @returns A DirectSecp256k1HdWallet object representing a newly generated wallet.
  * @category Wallets (Advanced)
  */
-export const generateWallet = async (mnemonicLength: 12 | 15 | 18 | 21 | 24 = 12, accountIndex?: number): Promise<DirectSecp256k1HdWallet> => {
+export const generateWallet = async (mnemonicLength: 12 | 15 | 18 | 21 | 24 = 12, hdPath?: HdPath): Promise<DirectSecp256k1HdWallet> => {
 	return await DirectSecp256k1HdWallet.generate(mnemonicLength, {
 		prefix: 'sei',
-		hdPaths: [getHdPath(accountIndex)]
+		hdPaths: [hdPath || getHdPath(0)]
 	});
 };
 
 /**
- * Uses the given mnemonic phrase and account index to re-generate a wallet.
+ * Uses the given mnemonic phrase and hd path to re-generate a wallet.
  *
  * @example
  * ```tsx
@@ -48,10 +49,10 @@ export const generateWallet = async (mnemonicLength: 12 | 15 | 18 | 21 | 24 = 12
  * ```
  *
  * @param seedPhrase The mnemonic phrase created with the wallet
- * @param accountIndex The account index.
+ * @param hdPath hdPath for the wallet you want to restore.
  * @returns A DirectSecp256k1HdWallet object representing an existing wallet.
  * @category Wallets (Advanced)
  */
-export const restoreWallet = async (seedPhrase: string, accountIndex?: number): Promise<DirectSecp256k1HdWallet> => {
-	return await DirectSecp256k1HdWallet.fromMnemonic(seedPhrase, { prefix: 'sei', hdPaths: [getHdPath(accountIndex)] });
+export const restoreWallet = async (seedPhrase: string, hdPath?: HdPath): Promise<DirectSecp256k1HdWallet> => {
+	return await DirectSecp256k1HdWallet.fromMnemonic(seedPhrase, { prefix: 'sei', hdPaths: [hdPath || getHdPath(0)] });
 };


### PR DESCRIPTION
There is [an old PR](https://github.com/sei-protocol/sei-js/pull/195) open that has some helper functions. Of those helpers all already are included in @sei-js except generating an address from a private key, so this PR adds that function.

