### PR TITLE
NPM Publish: Explicitly build before release

### DIFF
--- a/.changeset/red-rules-march.md
+++ b/.changeset/red-rules-march.md
@@ -1,0 +1,11 @@
+---
+"@sei-js/cosmjs": patch
+"@sei-js/cosmos": patch
+"@sei-js/create-sei": patch
+"@sei-js/evm": patch
+"@sei-js/ledger": patch
+"@sei-js/registry": patch
+"@sei-js/sei-global-wallet": patch
+---
+
+Fix broken NPM publish for all packages

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,5 +1,5 @@
 # runs if /packages/registry/** is updated and the release workflow completes successfully
-name: Release Package
+name: Update Registry Submodules
 
 on:
   workflow_run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
+      - name: Build Packages
+        run: yarn build:all
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
 		"postinstall": "yarn update-submodules",
 		"update-submodules": "git submodule update --init --recursive",
 		"docs": "npx typedoc",
-		"prerelease": "yarn build:all",
-		"release": "changeset publish",
-		"postrelease": "git push --follow-tags",
+		"release": "changeset publish && git push --follow-tags",
 		"release:internal": "yarn build:all && yarn changeset && yarn changeset version --snapshot internal && yarn changeset publish --no-git-tag --snapshot --tag internal",
 		"test:all": "yarn workspaces foreach --all run test",
 		"test:coverage": "yarn workspaces foreach --all run test --coverage"

--- a/packages/cosmjs/package.json
+++ b/packages/cosmjs/package.json
@@ -7,8 +7,7 @@
 	"types": "./dist/types/index.d.ts",
 	"sideEffects": false,
 	"scripts": {
-		"prebuild": "rimraf dist",
-		"build": "yarn build:types && yarn build:cjs && yarn build:esm",
+		"build": "rimraf dist && yarn build:types && yarn build:cjs && yarn build:esm",
 		"build:cjs": "tsc --outDir dist/cjs --module commonjs",
 		"build:esm": "tsc --outDir dist/esm --module esnext",
 		"build:types": "tsc --project ./tsconfig.declaration.json",
@@ -17,12 +16,7 @@
 		"lint": "eslint --ext .ts"
 	},
 	"homepage": "https://github.com/sei-protocol/sei-js#readme",
-	"keywords": [
-		"sei",
-		"javascript",
-		"typescript",
-		"react"
-	],
+	"keywords": ["sei", "javascript", "typescript", "react"],
 	"repository": "git@github.com:sei-protocol/sei-js.git",
 	"license": "MIT",
 	"publishConfig": {

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -7,8 +7,7 @@
 	"types": "./dist/types/index.d.ts",
 	"sideEffects": false,
 	"scripts": {
-		"prebuild": "rimraf dist",
-		"build": "yarn build:types && yarn build:cjs && yarn build:esm",
+		"build": "rimraf dist && yarn build:types && yarn build:cjs && yarn build:esm",
 		"build:cjs": "tsc --outDir dist/cjs --module commonjs",
 		"build:esm": "tsc --outDir dist/esm --module esnext",
 		"build:types": "tsc --project ./tsconfig.declaration.json",
@@ -16,13 +15,7 @@
 		"test": "jest --passWithNoTests"
 	},
 	"homepage": "https://github.com/sei-protocol/sei-js#readme",
-	"keywords": [
-		"sei",
-		"javascript",
-		"typescript",
-		"node",
-		"evm"
-	],
+	"keywords": ["sei", "javascript", "typescript", "node", "evm"],
 	"repository": "git@github.com:sei-protocol/sei-js.git",
 	"license": "MIT",
 	"publishConfig": {

--- a/packages/sei-global-wallet/package.json
+++ b/packages/sei-global-wallet/package.json
@@ -9,8 +9,7 @@
 	"typings": "./dist/types/index.d.ts",
 	"license": "ISC",
 	"scripts": {
-		"prebuild": "rimraf dist",
-		"build": "yarn build:types && yarn build:cjs && yarn build:esm",
+		"build": "rimraf dist && yarn build:types && yarn build:cjs && yarn build:esm",
 		"build:cjs": "tsc --outDir dist/cjs --module commonjs",
 		"build:esm": "tsc --outDir dist/esm --module esnext",
 		"build:types": "tsc --project ./tsconfig.declaration.json",
@@ -54,12 +53,8 @@
 	},
 	"typesVersions": {
 		"*": {
-			"eip6963": [
-				"./dist/types/eip6963.d.ts"
-			],
-			"solana-standard": [
-				"./dist/types/solana-standard.d.ts"
-			]
+			"eip6963": ["./dist/types/eip6963.d.ts"],
+			"solana-standard": ["./dist/types/solana-standard.d.ts"]
 		}
 	},
 	"exports": {


### PR DESCRIPTION
Previous yarn versions honored all pre/post npm scripts, but yarn v4 doesn't so the "prerelease" script which built the packages didn't run on the last release. Running `yarn build:all` explicitly will create all the "dist" directories for each package and running `yarn pack` in each package will generate the NPM package that includes the `dist`, so it is the github action that is the issue.

Example of installed library without the dist directory:

<img width="308" alt="Screenshot 2025-04-03 at 10 09 34 AM" src="https://github.com/user-attachments/assets/3b57d173-a8db-41cf-b833-8099e00853b9" />


Additionally this PR removes/updates all pre/post scripts throughout the repo.