### PR TITLE
Added tests for `@sei-js/sei-global-wallets`

### DIFF
--- a/packages/sei-global-wallet/jest.config.mjs
+++ b/packages/sei-global-wallet/jest.config.mjs
@@ -1,0 +1,12 @@
+/** @type {import('jest').Config} */
+export default {
+	preset: 'ts-jest/presets/default-esm',
+	testEnvironment: 'node',
+	transform: {
+		'^.+\\.ts$': ['ts-jest', { useESM: true }]
+	},
+	extensionsToTreatAsEsm: ['.ts'],
+	moduleNameMapper: {
+		'^(\\.{1,2}/.*)\\.js$': '$1'
+	}
+};

--- a/packages/sei-global-wallet/package.json
+++ b/packages/sei-global-wallet/package.json
@@ -12,7 +12,8 @@
 		"build": "rimraf dist && yarn build:types && yarn build:cjs && yarn build:esm",
 		"build:cjs": "tsc --outDir dist/cjs --module commonjs",
 		"build:esm": "tsc --outDir dist/esm --module esnext",
-		"build:types": "tsc --project ./tsconfig.declaration.json"
+		"build:types": "tsc --project ./tsconfig.declaration.json",
+		"test": "jest"
 	},
 	"dependencies": {
 		"@dynamic-labs/global-wallet-client": "^4.10.2",

--- a/packages/sei-global-wallet/src/lib/EIP6963Emitter.ts
+++ b/packages/sei-global-wallet/src/lib/EIP6963Emitter.ts
@@ -1,11 +1,12 @@
+import type { DataURIImage } from '@dynamic-labs/global-wallet-client';
 import { announceEip6963Provider, createEIP1193Provider } from '@dynamic-labs/global-wallet-client/ethereum';
-import Wallet from './wallet';
 import { config } from './config';
+import Wallet from './wallet';
 
 export const EIP6963Emitter = () => {
 	announceEip6963Provider({
 		info: {
-			icon: config.walletIcon as any,
+			icon: config.walletIcon as DataURIImage,
 			uuid: config.environmentId,
 			name: config.walletName,
 			rdns: config.eip6963.rdns

--- a/packages/sei-global-wallet/src/lib/__tests__/EIP6963Emitter.spec.ts
+++ b/packages/sei-global-wallet/src/lib/__tests__/EIP6963Emitter.spec.ts
@@ -1,0 +1,40 @@
+import { announceEip6963Provider, createEIP1193Provider } from '@dynamic-labs/global-wallet-client/ethereum';
+import { EIP6963Emitter } from '../EIP6963Emitter';
+import Wallet from '../wallet';
+
+jest.mock('@dynamic-labs/global-wallet-client/ethereum', () => ({
+	announceEip6963Provider: jest.fn(),
+	createEIP1193Provider: jest.fn()
+}));
+
+jest.mock('../wallet', () => ({}));
+jest.mock('../config', () => ({
+	config: {
+		walletIcon: 'icon-url',
+		environmentId: 'env-id',
+		walletName: 'SEI Wallet',
+		eip6963: {
+			rdns: 'com.sei.wallet'
+		}
+	}
+}));
+
+describe('EIP6963Emitter', () => {
+	it('should announce the provider with correct config and provider instance', () => {
+		const mockProvider = { foo: 'bar' };
+		(createEIP1193Provider as jest.Mock).mockReturnValue(mockProvider);
+
+		EIP6963Emitter();
+
+		expect(createEIP1193Provider).toHaveBeenCalledWith(Wallet);
+		expect(announceEip6963Provider).toHaveBeenCalledWith({
+			info: {
+				icon: 'icon-url',
+				uuid: 'env-id',
+				name: 'SEI Wallet',
+				rdns: 'com.sei.wallet'
+			},
+			provider: mockProvider
+		});
+	});
+});

--- a/packages/sei-global-wallet/src/lib/__tests__/registerSolanaStandard.ts
+++ b/packages/sei-global-wallet/src/lib/__tests__/registerSolanaStandard.ts
@@ -1,0 +1,35 @@
+import { createSolanaWallet, registerWallet } from '@dynamic-labs/global-wallet-client/solana';
+import { registerSolanaStandard } from '../registerSolanaStandard';
+import Wallet from '../wallet';
+
+jest.mock('@dynamic-labs/global-wallet-client/solana', () => ({
+	createSolanaWallet: jest.fn(),
+	registerWallet: jest.fn()
+}));
+
+jest.mock('../wallet', () => ({}));
+jest.mock('../config', () => ({
+	config: {
+		walletIcon: 'test-icon',
+		walletName: 'SEI Wallet'
+	}
+}));
+
+describe('registerSolanaStandard', () => {
+	it('calls createSolanaWallet and registers it', () => {
+		const mockWalletObject = { id: 'sei' };
+		(createSolanaWallet as jest.Mock).mockReturnValue(mockWalletObject);
+
+		registerSolanaStandard();
+
+		expect(createSolanaWallet).toHaveBeenCalledWith(
+			{
+				icon: 'test-icon',
+				name: 'SEI Wallet'
+			},
+			Wallet
+		);
+
+		expect(registerWallet).toHaveBeenCalledWith(mockWalletObject);
+	});
+});

--- a/packages/sei-global-wallet/src/lib/config.ts
+++ b/packages/sei-global-wallet/src/lib/config.ts
@@ -1,4 +1,17 @@
-export const config = {
+import type { DataURIImage } from '@dynamic-labs/global-wallet-client';
+import type { WalletIcon } from '@wallet-standard/base';
+
+interface EIP6963Config {
+	walletName: string;
+	walletIcon: DataURIImage | WalletIcon;
+	walletUrl: string;
+	environmentId: string;
+	eip6963: {
+		rdns: string;
+	};
+}
+
+export const config: EIP6963Config = {
 	// Wallet name will be seen as the Wallet name
 	walletName: 'Sei Global Wallet',
 	// Wallet icon will be seen as the Wallet icon

--- a/packages/sei-global-wallet/src/lib/registerSolanaStandard.ts
+++ b/packages/sei-global-wallet/src/lib/registerSolanaStandard.ts
@@ -1,12 +1,13 @@
-import Wallet from './wallet';
 import { createSolanaWallet, registerWallet } from '@dynamic-labs/global-wallet-client/solana';
+import type { WalletIcon } from '@wallet-standard/base';
 import { config } from './config';
+import Wallet from './wallet';
 
 export const registerSolanaStandard = () => {
 	registerWallet(
 		createSolanaWallet(
 			{
-				icon: config.walletIcon as any,
+				icon: config.walletIcon as WalletIcon,
 				name: config.walletName
 			},
 			Wallet


### PR DESCRIPTION
The `@sei-js/sei-global-wallets` package didn't contain any jest tests. For consistency and to achieve high coverage for all `@sei-js` repos, this PR adds test coverage to this library.

Additionally this PR improves typescript typing inside the config file and where it is used.