### PR TITLE
Add exports for confidential transfers module to `@sei-js/cosmos`

### DIFF
--- a/.changeset/gold-shrimps-nail.md
+++ b/.changeset/gold-shrimps-nail.md
@@ -1,0 +1,5 @@
+---
+"@sei-js/cosmos": patch
+---
+
+Add exports for the new Confidential Transfers Module

--- a/packages/cosmos/library/encoding/amino.ts
+++ b/packages/cosmos/library/encoding/amino.ts
@@ -1,4 +1,10 @@
 import type { AminoConverters } from "@cosmjs/stargate";
+import { aminoConverters as confidentialtransfers_confidential_amino } from "./confidentialtransfers/confidential";
+import { aminoConverters as confidentialtransfers_cryptography_amino } from "./confidentialtransfers/cryptography";
+import { aminoConverters as confidentialtransfers_genesis_amino } from "./confidentialtransfers/genesis";
+import { aminoConverters as confidentialtransfers_params_amino } from "./confidentialtransfers/params";
+import { aminoConverters as confidentialtransfers_tx_amino } from "./confidentialtransfers/tx";
+import { aminoConverters as confidentialtransfers_zk_amino } from "./confidentialtransfers/zk";
 import { aminoConverters as confio_proofs_amino } from "./confio/proofs";
 import { aminoConverters as cosmos_accesscontrol_accesscontrol_amino } from "./cosmos/accesscontrol/accesscontrol";
 import { aminoConverters as cosmos_accesscontrol_x_genesis_amino } from "./cosmos/accesscontrol_x/genesis";
@@ -112,6 +118,12 @@ import { aminoConverters as tokenfactory_params_amino } from "./tokenfactory/par
 import { aminoConverters as tokenfactory_tx_amino } from "./tokenfactory/tx";
 
 export const aminoConverters: AminoConverters = {
+	...confidentialtransfers_confidential_amino,
+	...confidentialtransfers_cryptography_amino,
+	...confidentialtransfers_genesis_amino,
+	...confidentialtransfers_params_amino,
+	...confidentialtransfers_tx_amino,
+	...confidentialtransfers_zk_amino,
 	...confio_proofs_amino,
 	...cosmos_accesscontrol_x_genesis_amino,
 	...cosmos_accesscontrol_x_query_amino,

--- a/packages/cosmos/library/encoding/confidentialtransfers/confidential.ts
+++ b/packages/cosmos/library/encoding/confidentialtransfers/confidential.ts
@@ -1,0 +1,271 @@
+import type { GeneratedType } from "@cosmjs/proto-signing";
+
+import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+
+import { Ciphertext } from "./cryptography";
+
+import type { CtAccountWithDenom as CtAccountWithDenom_type, CtAccount as CtAccount_type } from "../../types/confidentialtransfers";
+
+import type { DeepPartial, Exact, MessageFns } from "../common";
+
+export interface CtAccount extends CtAccount_type {}
+export interface CtAccountWithDenom extends CtAccountWithDenom_type {}
+
+export const CtAccount: MessageFns<CtAccount, "seiprotocol.seichain.confidentialtransfers.CtAccount"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.CtAccount" as const,
+
+	encode(message: CtAccount, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.public_key.length !== 0) {
+			writer.uint32(10).bytes(message.public_key);
+		}
+		if (message.pending_balance_lo !== undefined) {
+			Ciphertext.encode(message.pending_balance_lo, writer.uint32(18).fork()).join();
+		}
+		if (message.pending_balance_hi !== undefined) {
+			Ciphertext.encode(message.pending_balance_hi, writer.uint32(26).fork()).join();
+		}
+		if (message.pending_balance_credit_counter !== 0) {
+			writer.uint32(32).uint32(message.pending_balance_credit_counter);
+		}
+		if (message.available_balance !== undefined) {
+			Ciphertext.encode(message.available_balance, writer.uint32(42).fork()).join();
+		}
+		if (message.decryptable_available_balance !== "") {
+			writer.uint32(50).string(message.decryptable_available_balance);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): CtAccount {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseCtAccount();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.public_key = reader.bytes();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.pending_balance_lo = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.pending_balance_hi = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 4:
+					if (tag !== 32) {
+						break;
+					}
+
+					message.pending_balance_credit_counter = reader.uint32();
+					continue;
+				case 5:
+					if (tag !== 42) {
+						break;
+					}
+
+					message.available_balance = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 6:
+					if (tag !== 50) {
+						break;
+					}
+
+					message.decryptable_available_balance = reader.string();
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): CtAccount {
+		return {
+			public_key: isSet(object.public_key) ? bytesFromBase64(object.public_key) : new Uint8Array(0),
+			pending_balance_lo: isSet(object.pending_balance_lo) ? Ciphertext.fromJSON(object.pending_balance_lo) : undefined,
+			pending_balance_hi: isSet(object.pending_balance_hi) ? Ciphertext.fromJSON(object.pending_balance_hi) : undefined,
+			pending_balance_credit_counter: isSet(object.pending_balance_credit_counter) ? globalThis.Number(object.pending_balance_credit_counter) : 0,
+			available_balance: isSet(object.available_balance) ? Ciphertext.fromJSON(object.available_balance) : undefined,
+			decryptable_available_balance: isSet(object.decryptable_available_balance) ? globalThis.String(object.decryptable_available_balance) : ""
+		};
+	},
+
+	toJSON(message: CtAccount): unknown {
+		const obj: any = {};
+		if (message.public_key.length !== 0) {
+			obj.public_key = base64FromBytes(message.public_key);
+		}
+		if (message.pending_balance_lo !== undefined) {
+			obj.pending_balance_lo = Ciphertext.toJSON(message.pending_balance_lo);
+		}
+		if (message.pending_balance_hi !== undefined) {
+			obj.pending_balance_hi = Ciphertext.toJSON(message.pending_balance_hi);
+		}
+		if (message.pending_balance_credit_counter !== 0) {
+			obj.pending_balance_credit_counter = Math.round(message.pending_balance_credit_counter);
+		}
+		if (message.available_balance !== undefined) {
+			obj.available_balance = Ciphertext.toJSON(message.available_balance);
+		}
+		if (message.decryptable_available_balance !== "") {
+			obj.decryptable_available_balance = message.decryptable_available_balance;
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<CtAccount>, I>>(base?: I): CtAccount {
+		return CtAccount.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<CtAccount>, I>>(object: I): CtAccount {
+		const message = createBaseCtAccount();
+		message.public_key = object.public_key ?? new Uint8Array(0);
+		message.pending_balance_lo =
+			object.pending_balance_lo !== undefined && object.pending_balance_lo !== null ? Ciphertext.fromPartial(object.pending_balance_lo) : undefined;
+		message.pending_balance_hi =
+			object.pending_balance_hi !== undefined && object.pending_balance_hi !== null ? Ciphertext.fromPartial(object.pending_balance_hi) : undefined;
+		message.pending_balance_credit_counter = object.pending_balance_credit_counter ?? 0;
+		message.available_balance =
+			object.available_balance !== undefined && object.available_balance !== null ? Ciphertext.fromPartial(object.available_balance) : undefined;
+		message.decryptable_available_balance = object.decryptable_available_balance ?? "";
+		return message;
+	}
+};
+
+export const CtAccountWithDenom: MessageFns<CtAccountWithDenom, "seiprotocol.seichain.confidentialtransfers.CtAccountWithDenom"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.CtAccountWithDenom" as const,
+
+	encode(message: CtAccountWithDenom, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.denom !== "") {
+			writer.uint32(10).string(message.denom);
+		}
+		if (message.account !== undefined) {
+			CtAccount.encode(message.account, writer.uint32(18).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): CtAccountWithDenom {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseCtAccountWithDenom();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.denom = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.account = CtAccount.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): CtAccountWithDenom {
+		return {
+			denom: isSet(object.denom) ? globalThis.String(object.denom) : "",
+			account: isSet(object.account) ? CtAccount.fromJSON(object.account) : undefined
+		};
+	},
+
+	toJSON(message: CtAccountWithDenom): unknown {
+		const obj: any = {};
+		if (message.denom !== "") {
+			obj.denom = message.denom;
+		}
+		if (message.account !== undefined) {
+			obj.account = CtAccount.toJSON(message.account);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<CtAccountWithDenom>, I>>(base?: I): CtAccountWithDenom {
+		return CtAccountWithDenom.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<CtAccountWithDenom>, I>>(object: I): CtAccountWithDenom {
+		const message = createBaseCtAccountWithDenom();
+		message.denom = object.denom ?? "";
+		message.account = object.account !== undefined && object.account !== null ? CtAccount.fromPartial(object.account) : undefined;
+		return message;
+	}
+};
+
+function createBaseCtAccount(): CtAccount {
+	return {
+		public_key: new Uint8Array(0),
+		pending_balance_lo: undefined,
+		pending_balance_hi: undefined,
+		pending_balance_credit_counter: 0,
+		available_balance: undefined,
+		decryptable_available_balance: ""
+	};
+}
+
+function createBaseCtAccountWithDenom(): CtAccountWithDenom {
+	return { denom: "", account: undefined };
+}
+
+function bytesFromBase64(b64: string): Uint8Array {
+	if ((globalThis as any).Buffer) {
+		return Uint8Array.from(globalThis.Buffer.from(b64, "base64"));
+	} else {
+		const bin = globalThis.atob(b64);
+		const arr = new Uint8Array(bin.length);
+		for (let i = 0; i < bin.length; ++i) {
+			arr[i] = bin.charCodeAt(i);
+		}
+		return arr;
+	}
+}
+
+function base64FromBytes(arr: Uint8Array): string {
+	if ((globalThis as any).Buffer) {
+		return globalThis.Buffer.from(arr).toString("base64");
+	} else {
+		const bin: string[] = [];
+		arr.forEach((byte) => {
+			bin.push(globalThis.String.fromCharCode(byte));
+		});
+		return globalThis.btoa(bin.join(""));
+	}
+}
+
+function isSet(value: any): boolean {
+	return value !== null && value !== undefined;
+}
+export const registry: Array<[string, GeneratedType]> = [["/seiprotocol.seichain.confidentialtransfers.CtAccount", CtAccount as never]];
+export const aminoConverters = {
+	"/seiprotocol.seichain.confidentialtransfers.CtAccount": {
+		aminoType: "confidentialtransfers/CtAccount",
+		toAmino: (message: CtAccount) => ({ ...message }),
+		fromAmino: (object: CtAccount) => ({ ...object })
+	}
+};

--- a/packages/cosmos/library/encoding/confidentialtransfers/cryptography.ts
+++ b/packages/cosmos/library/encoding/confidentialtransfers/cryptography.ts
@@ -1,0 +1,122 @@
+import type { GeneratedType } from "@cosmjs/proto-signing";
+
+import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+
+import type { Ciphertext as Ciphertext_type } from "../../types/confidentialtransfers";
+
+import type { DeepPartial, Exact, MessageFns } from "../common";
+
+export interface Ciphertext extends Ciphertext_type {}
+
+export const Ciphertext: MessageFns<Ciphertext, "seiprotocol.seichain.confidentialtransfers.Ciphertext"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.Ciphertext" as const,
+
+	encode(message: Ciphertext, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.c.length !== 0) {
+			writer.uint32(10).bytes(message.c);
+		}
+		if (message.d.length !== 0) {
+			writer.uint32(18).bytes(message.d);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): Ciphertext {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseCiphertext();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.c = reader.bytes();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.d = reader.bytes();
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): Ciphertext {
+		return {
+			c: isSet(object.c) ? bytesFromBase64(object.c) : new Uint8Array(0),
+			d: isSet(object.d) ? bytesFromBase64(object.d) : new Uint8Array(0)
+		};
+	},
+
+	toJSON(message: Ciphertext): unknown {
+		const obj: any = {};
+		if (message.c.length !== 0) {
+			obj.c = base64FromBytes(message.c);
+		}
+		if (message.d.length !== 0) {
+			obj.d = base64FromBytes(message.d);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<Ciphertext>, I>>(base?: I): Ciphertext {
+		return Ciphertext.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<Ciphertext>, I>>(object: I): Ciphertext {
+		const message = createBaseCiphertext();
+		message.c = object.c ?? new Uint8Array(0);
+		message.d = object.d ?? new Uint8Array(0);
+		return message;
+	}
+};
+
+function createBaseCiphertext(): Ciphertext {
+	return { c: new Uint8Array(0), d: new Uint8Array(0) };
+}
+
+function bytesFromBase64(b64: string): Uint8Array {
+	if ((globalThis as any).Buffer) {
+		return Uint8Array.from(globalThis.Buffer.from(b64, "base64"));
+	} else {
+		const bin = globalThis.atob(b64);
+		const arr = new Uint8Array(bin.length);
+		for (let i = 0; i < bin.length; ++i) {
+			arr[i] = bin.charCodeAt(i);
+		}
+		return arr;
+	}
+}
+
+function base64FromBytes(arr: Uint8Array): string {
+	if ((globalThis as any).Buffer) {
+		return globalThis.Buffer.from(arr).toString("base64");
+	} else {
+		const bin: string[] = [];
+		arr.forEach((byte) => {
+			bin.push(globalThis.String.fromCharCode(byte));
+		});
+		return globalThis.btoa(bin.join(""));
+	}
+}
+
+function isSet(value: any): boolean {
+	return value !== null && value !== undefined;
+}
+export const registry: Array<[string, GeneratedType]> = [["/seiprotocol.seichain.confidentialtransfers.Ciphertext", Ciphertext as never]];
+export const aminoConverters = {
+	"/seiprotocol.seichain.confidentialtransfers.Ciphertext": {
+		aminoType: "confidentialtransfers/Ciphertext",
+		toAmino: (message: Ciphertext) => ({ ...message }),
+		fromAmino: (object: Ciphertext) => ({ ...object })
+	}
+};

--- a/packages/cosmos/library/encoding/confidentialtransfers/genesis.ts
+++ b/packages/cosmos/library/encoding/confidentialtransfers/genesis.ts
@@ -1,0 +1,203 @@
+import type { GeneratedType } from "@cosmjs/proto-signing";
+
+import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+
+import { CtAccount } from "./confidential";
+
+import { Params } from "./params";
+
+import type { GenesisCtAccount as GenesisCtAccount_type, GenesisState as GenesisState_type } from "../../types/confidentialtransfers";
+
+import type { DeepPartial, Exact, MessageFns } from "../common";
+
+export interface GenesisState extends GenesisState_type {}
+export interface GenesisCtAccount extends GenesisCtAccount_type {}
+
+export const GenesisState: MessageFns<GenesisState, "seiprotocol.seichain.confidentialtransfers.GenesisState"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.GenesisState" as const,
+
+	encode(message: GenesisState, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.params !== undefined) {
+			Params.encode(message.params, writer.uint32(10).fork()).join();
+		}
+		for (const v of message.accounts) {
+			GenesisCtAccount.encode(v!, writer.uint32(18).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): GenesisState {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseGenesisState();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.params = Params.decode(reader, reader.uint32());
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.accounts.push(GenesisCtAccount.decode(reader, reader.uint32()));
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): GenesisState {
+		return {
+			params: isSet(object.params) ? Params.fromJSON(object.params) : undefined,
+			accounts: globalThis.Array.isArray(object?.accounts) ? object.accounts.map((e: any) => GenesisCtAccount.fromJSON(e)) : []
+		};
+	},
+
+	toJSON(message: GenesisState): unknown {
+		const obj: any = {};
+		if (message.params !== undefined) {
+			obj.params = Params.toJSON(message.params);
+		}
+		if (message.accounts?.length) {
+			obj.accounts = message.accounts.map((e) => GenesisCtAccount.toJSON(e));
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<GenesisState>, I>>(base?: I): GenesisState {
+		return GenesisState.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<GenesisState>, I>>(object: I): GenesisState {
+		const message = createBaseGenesisState();
+		message.params = object.params !== undefined && object.params !== null ? Params.fromPartial(object.params) : undefined;
+		message.accounts = object.accounts?.map((e) => GenesisCtAccount.fromPartial(e)) || [];
+		return message;
+	}
+};
+
+export const GenesisCtAccount: MessageFns<GenesisCtAccount, "seiprotocol.seichain.confidentialtransfers.GenesisCtAccount"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.GenesisCtAccount" as const,
+
+	encode(message: GenesisCtAccount, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.key.length !== 0) {
+			writer.uint32(10).bytes(message.key);
+		}
+		if (message.account !== undefined) {
+			CtAccount.encode(message.account, writer.uint32(18).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): GenesisCtAccount {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseGenesisCtAccount();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.key = reader.bytes();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.account = CtAccount.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): GenesisCtAccount {
+		return {
+			key: isSet(object.key) ? bytesFromBase64(object.key) : new Uint8Array(0),
+			account: isSet(object.account) ? CtAccount.fromJSON(object.account) : undefined
+		};
+	},
+
+	toJSON(message: GenesisCtAccount): unknown {
+		const obj: any = {};
+		if (message.key.length !== 0) {
+			obj.key = base64FromBytes(message.key);
+		}
+		if (message.account !== undefined) {
+			obj.account = CtAccount.toJSON(message.account);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<GenesisCtAccount>, I>>(base?: I): GenesisCtAccount {
+		return GenesisCtAccount.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<GenesisCtAccount>, I>>(object: I): GenesisCtAccount {
+		const message = createBaseGenesisCtAccount();
+		message.key = object.key ?? new Uint8Array(0);
+		message.account = object.account !== undefined && object.account !== null ? CtAccount.fromPartial(object.account) : undefined;
+		return message;
+	}
+};
+
+function createBaseGenesisState(): GenesisState {
+	return { params: undefined, accounts: [] };
+}
+
+function createBaseGenesisCtAccount(): GenesisCtAccount {
+	return { key: new Uint8Array(0), account: undefined };
+}
+
+function bytesFromBase64(b64: string): Uint8Array {
+	if ((globalThis as any).Buffer) {
+		return Uint8Array.from(globalThis.Buffer.from(b64, "base64"));
+	} else {
+		const bin = globalThis.atob(b64);
+		const arr = new Uint8Array(bin.length);
+		for (let i = 0; i < bin.length; ++i) {
+			arr[i] = bin.charCodeAt(i);
+		}
+		return arr;
+	}
+}
+
+function base64FromBytes(arr: Uint8Array): string {
+	if ((globalThis as any).Buffer) {
+		return globalThis.Buffer.from(arr).toString("base64");
+	} else {
+		const bin: string[] = [];
+		arr.forEach((byte) => {
+			bin.push(globalThis.String.fromCharCode(byte));
+		});
+		return globalThis.btoa(bin.join(""));
+	}
+}
+
+function isSet(value: any): boolean {
+	return value !== null && value !== undefined;
+}
+export const registry: Array<[string, GeneratedType]> = [["/seiprotocol.seichain.confidentialtransfers.GenesisState", GenesisState as never]];
+export const aminoConverters = {
+	"/seiprotocol.seichain.confidentialtransfers.GenesisState": {
+		aminoType: "confidentialtransfers/GenesisState",
+		toAmino: (message: GenesisState) => ({ ...message }),
+		fromAmino: (object: GenesisState) => ({ ...object })
+	}
+};

--- a/packages/cosmos/library/encoding/confidentialtransfers/index.ts
+++ b/packages/cosmos/library/encoding/confidentialtransfers/index.ts
@@ -1,0 +1,9 @@
+// @ts-nocheck
+
+export * from "./confidential";
+export * from "./cryptography";
+export * from "./genesis";
+export * from "./params";
+export * from "./query";
+export * from "./tx";
+export * from "./zk";

--- a/packages/cosmos/library/encoding/confidentialtransfers/params.ts
+++ b/packages/cosmos/library/encoding/confidentialtransfers/params.ts
@@ -1,0 +1,159 @@
+import type { GeneratedType } from "@cosmjs/proto-signing";
+
+import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+
+import type { Params as Params_type } from "../../types/confidentialtransfers";
+
+import type { DeepPartial, Exact, MessageFns } from "../common";
+
+export interface Params extends Params_type {}
+
+export const Params: MessageFns<Params, "seiprotocol.seichain.confidentialtransfers.Params"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.Params" as const,
+
+	encode(message: Params, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.enable_ct_module !== false) {
+			writer.uint32(8).bool(message.enable_ct_module);
+		}
+		if (message.range_proof_gas_cost !== 0) {
+			writer.uint32(16).uint64(message.range_proof_gas_cost);
+		}
+		for (const v of message.enabled_denoms) {
+			writer.uint32(26).string(v!);
+		}
+		if (message.ciphertext_gas_cost !== 0) {
+			writer.uint32(32).uint64(message.ciphertext_gas_cost);
+		}
+		if (message.proof_verification_gas_cost !== 0) {
+			writer.uint32(40).uint64(message.proof_verification_gas_cost);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): Params {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseParams();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 8) {
+						break;
+					}
+
+					message.enable_ct_module = reader.bool();
+					continue;
+				case 2:
+					if (tag !== 16) {
+						break;
+					}
+
+					message.range_proof_gas_cost = longToNumber(reader.uint64());
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.enabled_denoms.push(reader.string());
+					continue;
+				case 4:
+					if (tag !== 32) {
+						break;
+					}
+
+					message.ciphertext_gas_cost = longToNumber(reader.uint64());
+					continue;
+				case 5:
+					if (tag !== 40) {
+						break;
+					}
+
+					message.proof_verification_gas_cost = longToNumber(reader.uint64());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): Params {
+		return {
+			enable_ct_module: isSet(object.enable_ct_module) ? globalThis.Boolean(object.enable_ct_module) : false,
+			range_proof_gas_cost: isSet(object.range_proof_gas_cost) ? globalThis.Number(object.range_proof_gas_cost) : 0,
+			enabled_denoms: globalThis.Array.isArray(object?.enabled_denoms) ? object.enabled_denoms.map((e: any) => globalThis.String(e)) : [],
+			ciphertext_gas_cost: isSet(object.ciphertext_gas_cost) ? globalThis.Number(object.ciphertext_gas_cost) : 0,
+			proof_verification_gas_cost: isSet(object.proof_verification_gas_cost) ? globalThis.Number(object.proof_verification_gas_cost) : 0
+		};
+	},
+
+	toJSON(message: Params): unknown {
+		const obj: any = {};
+		if (message.enable_ct_module !== false) {
+			obj.enable_ct_module = message.enable_ct_module;
+		}
+		if (message.range_proof_gas_cost !== 0) {
+			obj.range_proof_gas_cost = Math.round(message.range_proof_gas_cost);
+		}
+		if (message.enabled_denoms?.length) {
+			obj.enabled_denoms = message.enabled_denoms;
+		}
+		if (message.ciphertext_gas_cost !== 0) {
+			obj.ciphertext_gas_cost = Math.round(message.ciphertext_gas_cost);
+		}
+		if (message.proof_verification_gas_cost !== 0) {
+			obj.proof_verification_gas_cost = Math.round(message.proof_verification_gas_cost);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<Params>, I>>(base?: I): Params {
+		return Params.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<Params>, I>>(object: I): Params {
+		const message = createBaseParams();
+		message.enable_ct_module = object.enable_ct_module ?? false;
+		message.range_proof_gas_cost = object.range_proof_gas_cost ?? 0;
+		message.enabled_denoms = object.enabled_denoms?.map((e) => e) || [];
+		message.ciphertext_gas_cost = object.ciphertext_gas_cost ?? 0;
+		message.proof_verification_gas_cost = object.proof_verification_gas_cost ?? 0;
+		return message;
+	}
+};
+
+function createBaseParams(): Params {
+	return {
+		enable_ct_module: false,
+		range_proof_gas_cost: 0,
+		enabled_denoms: [],
+		ciphertext_gas_cost: 0,
+		proof_verification_gas_cost: 0
+	};
+}
+
+function longToNumber(int64: { toString(): string }): number {
+	const num = globalThis.Number(int64.toString());
+	if (num > globalThis.Number.MAX_SAFE_INTEGER) {
+		throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+	}
+	if (num < globalThis.Number.MIN_SAFE_INTEGER) {
+		throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
+	}
+	return num;
+}
+
+function isSet(value: any): boolean {
+	return value !== null && value !== undefined;
+}
+export const registry: Array<[string, GeneratedType]> = [["/seiprotocol.seichain.confidentialtransfers.Params", Params as never]];
+export const aminoConverters = {
+	"/seiprotocol.seichain.confidentialtransfers.Params": {
+		aminoType: "confidentialtransfers/Params",
+		toAmino: (message: Params) => ({ ...message }),
+		fromAmino: (object: Params) => ({ ...object })
+	}
+};

--- a/packages/cosmos/library/encoding/confidentialtransfers/query.ts
+++ b/packages/cosmos/library/encoding/confidentialtransfers/query.ts
@@ -1,0 +1,1170 @@
+import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+
+import { PageRequest, PageResponse } from "../cosmos/base/query/v1beta1/pagination";
+
+import { CtAccount, CtAccountWithDenom } from "./confidential";
+
+import { InitializeAccountMsgProofs, TransferMsgProofs, WithdrawMsgProofs } from "./zk";
+
+import type {
+	ApplyPendingBalanceDecrypted as ApplyPendingBalanceDecrypted_type,
+	DecryptedCtAccount as DecryptedCtAccount_type,
+	GetAllCtAccountsRequest as GetAllCtAccountsRequest_type,
+	GetAllCtAccountsResponse as GetAllCtAccountsResponse_type,
+	GetCtAccountRequest as GetCtAccountRequest_type,
+	GetCtAccountResponse as GetCtAccountResponse_type,
+	InitializeAccountDecrypted as InitializeAccountDecrypted_type,
+	TransferDecrypted as TransferDecrypted_type,
+	WithdrawDecrypted as WithdrawDecrypted_type
+} from "../../types/confidentialtransfers";
+
+import type { DeepPartial, Exact, MessageFns } from "../common";
+
+export interface GetCtAccountRequest extends GetCtAccountRequest_type {}
+export interface GetCtAccountResponse extends GetCtAccountResponse_type {}
+export interface GetAllCtAccountsRequest extends GetAllCtAccountsRequest_type {}
+export interface GetAllCtAccountsResponse extends GetAllCtAccountsResponse_type {}
+export interface DecryptedCtAccount extends DecryptedCtAccount_type {}
+export interface ApplyPendingBalanceDecrypted extends ApplyPendingBalanceDecrypted_type {}
+export interface InitializeAccountDecrypted extends InitializeAccountDecrypted_type {}
+export interface WithdrawDecrypted extends WithdrawDecrypted_type {}
+export interface TransferDecrypted extends TransferDecrypted_type {}
+
+export const GetCtAccountRequest: MessageFns<GetCtAccountRequest, "seiprotocol.seichain.confidentialtransfers.GetCtAccountRequest"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.GetCtAccountRequest" as const,
+
+	encode(message: GetCtAccountRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.address !== "") {
+			writer.uint32(10).string(message.address);
+		}
+		if (message.denom !== "") {
+			writer.uint32(18).string(message.denom);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): GetCtAccountRequest {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseGetCtAccountRequest();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.denom = reader.string();
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): GetCtAccountRequest {
+		return {
+			address: isSet(object.address) ? globalThis.String(object.address) : "",
+			denom: isSet(object.denom) ? globalThis.String(object.denom) : ""
+		};
+	},
+
+	toJSON(message: GetCtAccountRequest): unknown {
+		const obj: any = {};
+		if (message.address !== "") {
+			obj.address = message.address;
+		}
+		if (message.denom !== "") {
+			obj.denom = message.denom;
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<GetCtAccountRequest>, I>>(base?: I): GetCtAccountRequest {
+		return GetCtAccountRequest.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<GetCtAccountRequest>, I>>(object: I): GetCtAccountRequest {
+		const message = createBaseGetCtAccountRequest();
+		message.address = object.address ?? "";
+		message.denom = object.denom ?? "";
+		return message;
+	}
+};
+
+export const GetCtAccountResponse: MessageFns<GetCtAccountResponse, "seiprotocol.seichain.confidentialtransfers.GetCtAccountResponse"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.GetCtAccountResponse" as const,
+
+	encode(message: GetCtAccountResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.account !== undefined) {
+			CtAccount.encode(message.account, writer.uint32(10).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): GetCtAccountResponse {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseGetCtAccountResponse();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.account = CtAccount.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): GetCtAccountResponse {
+		return { account: isSet(object.account) ? CtAccount.fromJSON(object.account) : undefined };
+	},
+
+	toJSON(message: GetCtAccountResponse): unknown {
+		const obj: any = {};
+		if (message.account !== undefined) {
+			obj.account = CtAccount.toJSON(message.account);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<GetCtAccountResponse>, I>>(base?: I): GetCtAccountResponse {
+		return GetCtAccountResponse.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<GetCtAccountResponse>, I>>(object: I): GetCtAccountResponse {
+		const message = createBaseGetCtAccountResponse();
+		message.account = object.account !== undefined && object.account !== null ? CtAccount.fromPartial(object.account) : undefined;
+		return message;
+	}
+};
+
+export const GetAllCtAccountsRequest: MessageFns<GetAllCtAccountsRequest, "seiprotocol.seichain.confidentialtransfers.GetAllCtAccountsRequest"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.GetAllCtAccountsRequest" as const,
+
+	encode(message: GetAllCtAccountsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.address !== "") {
+			writer.uint32(10).string(message.address);
+		}
+		if (message.pagination !== undefined) {
+			PageRequest.encode(message.pagination, writer.uint32(18).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): GetAllCtAccountsRequest {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseGetAllCtAccountsRequest();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.pagination = PageRequest.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): GetAllCtAccountsRequest {
+		return {
+			address: isSet(object.address) ? globalThis.String(object.address) : "",
+			pagination: isSet(object.pagination) ? PageRequest.fromJSON(object.pagination) : undefined
+		};
+	},
+
+	toJSON(message: GetAllCtAccountsRequest): unknown {
+		const obj: any = {};
+		if (message.address !== "") {
+			obj.address = message.address;
+		}
+		if (message.pagination !== undefined) {
+			obj.pagination = PageRequest.toJSON(message.pagination);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<GetAllCtAccountsRequest>, I>>(base?: I): GetAllCtAccountsRequest {
+		return GetAllCtAccountsRequest.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<GetAllCtAccountsRequest>, I>>(object: I): GetAllCtAccountsRequest {
+		const message = createBaseGetAllCtAccountsRequest();
+		message.address = object.address ?? "";
+		message.pagination = object.pagination !== undefined && object.pagination !== null ? PageRequest.fromPartial(object.pagination) : undefined;
+		return message;
+	}
+};
+
+export const GetAllCtAccountsResponse: MessageFns<GetAllCtAccountsResponse, "seiprotocol.seichain.confidentialtransfers.GetAllCtAccountsResponse"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.GetAllCtAccountsResponse" as const,
+
+	encode(message: GetAllCtAccountsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		for (const v of message.accounts) {
+			CtAccountWithDenom.encode(v!, writer.uint32(10).fork()).join();
+		}
+		if (message.pagination !== undefined) {
+			PageResponse.encode(message.pagination, writer.uint32(18).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): GetAllCtAccountsResponse {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseGetAllCtAccountsResponse();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.accounts.push(CtAccountWithDenom.decode(reader, reader.uint32()));
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.pagination = PageResponse.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): GetAllCtAccountsResponse {
+		return {
+			accounts: globalThis.Array.isArray(object?.accounts) ? object.accounts.map((e: any) => CtAccountWithDenom.fromJSON(e)) : [],
+			pagination: isSet(object.pagination) ? PageResponse.fromJSON(object.pagination) : undefined
+		};
+	},
+
+	toJSON(message: GetAllCtAccountsResponse): unknown {
+		const obj: any = {};
+		if (message.accounts?.length) {
+			obj.accounts = message.accounts.map((e) => CtAccountWithDenom.toJSON(e));
+		}
+		if (message.pagination !== undefined) {
+			obj.pagination = PageResponse.toJSON(message.pagination);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<GetAllCtAccountsResponse>, I>>(base?: I): GetAllCtAccountsResponse {
+		return GetAllCtAccountsResponse.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<GetAllCtAccountsResponse>, I>>(object: I): GetAllCtAccountsResponse {
+		const message = createBaseGetAllCtAccountsResponse();
+		message.accounts = object.accounts?.map((e) => CtAccountWithDenom.fromPartial(e)) || [];
+		message.pagination = object.pagination !== undefined && object.pagination !== null ? PageResponse.fromPartial(object.pagination) : undefined;
+		return message;
+	}
+};
+
+export const DecryptedCtAccount: MessageFns<DecryptedCtAccount, "seiprotocol.seichain.confidentialtransfers.DecryptedCtAccount"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.DecryptedCtAccount" as const,
+
+	encode(message: DecryptedCtAccount, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.public_key.length !== 0) {
+			writer.uint32(10).bytes(message.public_key);
+		}
+		if (message.pending_balance_lo !== 0) {
+			writer.uint32(16).uint64(message.pending_balance_lo);
+		}
+		if (message.pending_balance_hi !== 0) {
+			writer.uint32(24).uint64(message.pending_balance_hi);
+		}
+		if (message.combined_pending_balance !== "") {
+			writer.uint32(34).string(message.combined_pending_balance);
+		}
+		if (message.pending_balance_credit_counter !== 0) {
+			writer.uint32(40).uint32(message.pending_balance_credit_counter);
+		}
+		if (message.available_balance !== "") {
+			writer.uint32(50).string(message.available_balance);
+		}
+		if (message.decryptable_available_balance !== "") {
+			writer.uint32(58).string(message.decryptable_available_balance);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): DecryptedCtAccount {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseDecryptedCtAccount();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.public_key = reader.bytes();
+					continue;
+				case 2:
+					if (tag !== 16) {
+						break;
+					}
+
+					message.pending_balance_lo = longToNumber(reader.uint64());
+					continue;
+				case 3:
+					if (tag !== 24) {
+						break;
+					}
+
+					message.pending_balance_hi = longToNumber(reader.uint64());
+					continue;
+				case 4:
+					if (tag !== 34) {
+						break;
+					}
+
+					message.combined_pending_balance = reader.string();
+					continue;
+				case 5:
+					if (tag !== 40) {
+						break;
+					}
+
+					message.pending_balance_credit_counter = reader.uint32();
+					continue;
+				case 6:
+					if (tag !== 50) {
+						break;
+					}
+
+					message.available_balance = reader.string();
+					continue;
+				case 7:
+					if (tag !== 58) {
+						break;
+					}
+
+					message.decryptable_available_balance = reader.string();
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): DecryptedCtAccount {
+		return {
+			public_key: isSet(object.public_key) ? bytesFromBase64(object.public_key) : new Uint8Array(0),
+			pending_balance_lo: isSet(object.pending_balance_lo) ? globalThis.Number(object.pending_balance_lo) : 0,
+			pending_balance_hi: isSet(object.pending_balance_hi) ? globalThis.Number(object.pending_balance_hi) : 0,
+			combined_pending_balance: isSet(object.combined_pending_balance) ? globalThis.String(object.combined_pending_balance) : "",
+			pending_balance_credit_counter: isSet(object.pending_balance_credit_counter) ? globalThis.Number(object.pending_balance_credit_counter) : 0,
+			available_balance: isSet(object.available_balance) ? globalThis.String(object.available_balance) : "",
+			decryptable_available_balance: isSet(object.decryptable_available_balance) ? globalThis.String(object.decryptable_available_balance) : ""
+		};
+	},
+
+	toJSON(message: DecryptedCtAccount): unknown {
+		const obj: any = {};
+		if (message.public_key.length !== 0) {
+			obj.public_key = base64FromBytes(message.public_key);
+		}
+		if (message.pending_balance_lo !== 0) {
+			obj.pending_balance_lo = Math.round(message.pending_balance_lo);
+		}
+		if (message.pending_balance_hi !== 0) {
+			obj.pending_balance_hi = Math.round(message.pending_balance_hi);
+		}
+		if (message.combined_pending_balance !== "") {
+			obj.combined_pending_balance = message.combined_pending_balance;
+		}
+		if (message.pending_balance_credit_counter !== 0) {
+			obj.pending_balance_credit_counter = Math.round(message.pending_balance_credit_counter);
+		}
+		if (message.available_balance !== "") {
+			obj.available_balance = message.available_balance;
+		}
+		if (message.decryptable_available_balance !== "") {
+			obj.decryptable_available_balance = message.decryptable_available_balance;
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<DecryptedCtAccount>, I>>(base?: I): DecryptedCtAccount {
+		return DecryptedCtAccount.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<DecryptedCtAccount>, I>>(object: I): DecryptedCtAccount {
+		const message = createBaseDecryptedCtAccount();
+		message.public_key = object.public_key ?? new Uint8Array(0);
+		message.pending_balance_lo = object.pending_balance_lo ?? 0;
+		message.pending_balance_hi = object.pending_balance_hi ?? 0;
+		message.combined_pending_balance = object.combined_pending_balance ?? "";
+		message.pending_balance_credit_counter = object.pending_balance_credit_counter ?? 0;
+		message.available_balance = object.available_balance ?? "";
+		message.decryptable_available_balance = object.decryptable_available_balance ?? "";
+		return message;
+	}
+};
+
+export const ApplyPendingBalanceDecrypted: MessageFns<ApplyPendingBalanceDecrypted, "seiprotocol.seichain.confidentialtransfers.ApplyPendingBalanceDecrypted"> =
+	{
+		$type: "seiprotocol.seichain.confidentialtransfers.ApplyPendingBalanceDecrypted" as const,
+
+		encode(message: ApplyPendingBalanceDecrypted, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+			if (message.address !== "") {
+				writer.uint32(10).string(message.address);
+			}
+			if (message.denom !== "") {
+				writer.uint32(18).string(message.denom);
+			}
+			if (message.new_decryptable_available_balance !== "") {
+				writer.uint32(26).string(message.new_decryptable_available_balance);
+			}
+			if (message.current_pending_balance_counter !== 0) {
+				writer.uint32(32).uint32(message.current_pending_balance_counter);
+			}
+			if (message.current_available_balance !== "") {
+				writer.uint32(42).string(message.current_available_balance);
+			}
+			return writer;
+		},
+
+		decode(input: BinaryReader | Uint8Array, length?: number): ApplyPendingBalanceDecrypted {
+			const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+			const end = length === undefined ? reader.len : reader.pos + length;
+			const message = createBaseApplyPendingBalanceDecrypted();
+			while (reader.pos < end) {
+				const tag = reader.uint32();
+				switch (tag >>> 3) {
+					case 1:
+						if (tag !== 10) {
+							break;
+						}
+
+						message.address = reader.string();
+						continue;
+					case 2:
+						if (tag !== 18) {
+							break;
+						}
+
+						message.denom = reader.string();
+						continue;
+					case 3:
+						if (tag !== 26) {
+							break;
+						}
+
+						message.new_decryptable_available_balance = reader.string();
+						continue;
+					case 4:
+						if (tag !== 32) {
+							break;
+						}
+
+						message.current_pending_balance_counter = reader.uint32();
+						continue;
+					case 5:
+						if (tag !== 42) {
+							break;
+						}
+
+						message.current_available_balance = reader.string();
+						continue;
+				}
+				if ((tag & 7) === 4 || tag === 0) {
+					break;
+				}
+				reader.skip(tag & 7);
+			}
+			return message;
+		},
+
+		fromJSON(object: any): ApplyPendingBalanceDecrypted {
+			return {
+				address: isSet(object.address) ? globalThis.String(object.address) : "",
+				denom: isSet(object.denom) ? globalThis.String(object.denom) : "",
+				new_decryptable_available_balance: isSet(object.new_decryptable_available_balance) ? globalThis.String(object.new_decryptable_available_balance) : "",
+				current_pending_balance_counter: isSet(object.current_pending_balance_counter) ? globalThis.Number(object.current_pending_balance_counter) : 0,
+				current_available_balance: isSet(object.current_available_balance) ? globalThis.String(object.current_available_balance) : ""
+			};
+		},
+
+		toJSON(message: ApplyPendingBalanceDecrypted): unknown {
+			const obj: any = {};
+			if (message.address !== "") {
+				obj.address = message.address;
+			}
+			if (message.denom !== "") {
+				obj.denom = message.denom;
+			}
+			if (message.new_decryptable_available_balance !== "") {
+				obj.new_decryptable_available_balance = message.new_decryptable_available_balance;
+			}
+			if (message.current_pending_balance_counter !== 0) {
+				obj.current_pending_balance_counter = Math.round(message.current_pending_balance_counter);
+			}
+			if (message.current_available_balance !== "") {
+				obj.current_available_balance = message.current_available_balance;
+			}
+			return obj;
+		},
+
+		create<I extends Exact<DeepPartial<ApplyPendingBalanceDecrypted>, I>>(base?: I): ApplyPendingBalanceDecrypted {
+			return ApplyPendingBalanceDecrypted.fromPartial(base ?? ({} as any));
+		},
+		fromPartial<I extends Exact<DeepPartial<ApplyPendingBalanceDecrypted>, I>>(object: I): ApplyPendingBalanceDecrypted {
+			const message = createBaseApplyPendingBalanceDecrypted();
+			message.address = object.address ?? "";
+			message.denom = object.denom ?? "";
+			message.new_decryptable_available_balance = object.new_decryptable_available_balance ?? "";
+			message.current_pending_balance_counter = object.current_pending_balance_counter ?? 0;
+			message.current_available_balance = object.current_available_balance ?? "";
+			return message;
+		}
+	};
+
+export const InitializeAccountDecrypted: MessageFns<InitializeAccountDecrypted, "seiprotocol.seichain.confidentialtransfers.InitializeAccountDecrypted"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.InitializeAccountDecrypted" as const,
+
+	encode(message: InitializeAccountDecrypted, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.from_address !== "") {
+			writer.uint32(10).string(message.from_address);
+		}
+		if (message.denom !== "") {
+			writer.uint32(18).string(message.denom);
+		}
+		if (message.pubkey.length !== 0) {
+			writer.uint32(26).bytes(message.pubkey);
+		}
+		if (message.pending_balance_lo !== 0) {
+			writer.uint32(32).uint32(message.pending_balance_lo);
+		}
+		if (message.pending_balance_hi !== 0) {
+			writer.uint32(40).uint64(message.pending_balance_hi);
+		}
+		if (message.available_balance !== "") {
+			writer.uint32(50).string(message.available_balance);
+		}
+		if (message.decryptable_balance !== "") {
+			writer.uint32(58).string(message.decryptable_balance);
+		}
+		if (message.proofs !== undefined) {
+			InitializeAccountMsgProofs.encode(message.proofs, writer.uint32(66).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): InitializeAccountDecrypted {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseInitializeAccountDecrypted();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.from_address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.denom = reader.string();
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.pubkey = reader.bytes();
+					continue;
+				case 4:
+					if (tag !== 32) {
+						break;
+					}
+
+					message.pending_balance_lo = reader.uint32();
+					continue;
+				case 5:
+					if (tag !== 40) {
+						break;
+					}
+
+					message.pending_balance_hi = longToNumber(reader.uint64());
+					continue;
+				case 6:
+					if (tag !== 50) {
+						break;
+					}
+
+					message.available_balance = reader.string();
+					continue;
+				case 7:
+					if (tag !== 58) {
+						break;
+					}
+
+					message.decryptable_balance = reader.string();
+					continue;
+				case 8:
+					if (tag !== 66) {
+						break;
+					}
+
+					message.proofs = InitializeAccountMsgProofs.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): InitializeAccountDecrypted {
+		return {
+			from_address: isSet(object.from_address) ? globalThis.String(object.from_address) : "",
+			denom: isSet(object.denom) ? globalThis.String(object.denom) : "",
+			pubkey: isSet(object.pubkey) ? bytesFromBase64(object.pubkey) : new Uint8Array(0),
+			pending_balance_lo: isSet(object.pending_balance_lo) ? globalThis.Number(object.pending_balance_lo) : 0,
+			pending_balance_hi: isSet(object.pending_balance_hi) ? globalThis.Number(object.pending_balance_hi) : 0,
+			available_balance: isSet(object.available_balance) ? globalThis.String(object.available_balance) : "",
+			decryptable_balance: isSet(object.decryptable_balance) ? globalThis.String(object.decryptable_balance) : "",
+			proofs: isSet(object.proofs) ? InitializeAccountMsgProofs.fromJSON(object.proofs) : undefined
+		};
+	},
+
+	toJSON(message: InitializeAccountDecrypted): unknown {
+		const obj: any = {};
+		if (message.from_address !== "") {
+			obj.from_address = message.from_address;
+		}
+		if (message.denom !== "") {
+			obj.denom = message.denom;
+		}
+		if (message.pubkey.length !== 0) {
+			obj.pubkey = base64FromBytes(message.pubkey);
+		}
+		if (message.pending_balance_lo !== 0) {
+			obj.pending_balance_lo = Math.round(message.pending_balance_lo);
+		}
+		if (message.pending_balance_hi !== 0) {
+			obj.pending_balance_hi = Math.round(message.pending_balance_hi);
+		}
+		if (message.available_balance !== "") {
+			obj.available_balance = message.available_balance;
+		}
+		if (message.decryptable_balance !== "") {
+			obj.decryptable_balance = message.decryptable_balance;
+		}
+		if (message.proofs !== undefined) {
+			obj.proofs = InitializeAccountMsgProofs.toJSON(message.proofs);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<InitializeAccountDecrypted>, I>>(base?: I): InitializeAccountDecrypted {
+		return InitializeAccountDecrypted.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<InitializeAccountDecrypted>, I>>(object: I): InitializeAccountDecrypted {
+		const message = createBaseInitializeAccountDecrypted();
+		message.from_address = object.from_address ?? "";
+		message.denom = object.denom ?? "";
+		message.pubkey = object.pubkey ?? new Uint8Array(0);
+		message.pending_balance_lo = object.pending_balance_lo ?? 0;
+		message.pending_balance_hi = object.pending_balance_hi ?? 0;
+		message.available_balance = object.available_balance ?? "";
+		message.decryptable_balance = object.decryptable_balance ?? "";
+		message.proofs = object.proofs !== undefined && object.proofs !== null ? InitializeAccountMsgProofs.fromPartial(object.proofs) : undefined;
+		return message;
+	}
+};
+
+export const WithdrawDecrypted: MessageFns<WithdrawDecrypted, "seiprotocol.seichain.confidentialtransfers.WithdrawDecrypted"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.WithdrawDecrypted" as const,
+
+	encode(message: WithdrawDecrypted, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.from_address !== "") {
+			writer.uint32(10).string(message.from_address);
+		}
+		if (message.denom !== "") {
+			writer.uint32(18).string(message.denom);
+		}
+		if (message.amount !== "") {
+			writer.uint32(26).string(message.amount);
+		}
+		if (message.decryptable_balance !== "") {
+			writer.uint32(34).string(message.decryptable_balance);
+		}
+		if (message.remaining_balance_commitment !== "") {
+			writer.uint32(42).string(message.remaining_balance_commitment);
+		}
+		if (message.proofs !== undefined) {
+			WithdrawMsgProofs.encode(message.proofs, writer.uint32(50).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): WithdrawDecrypted {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseWithdrawDecrypted();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.from_address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.denom = reader.string();
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.amount = reader.string();
+					continue;
+				case 4:
+					if (tag !== 34) {
+						break;
+					}
+
+					message.decryptable_balance = reader.string();
+					continue;
+				case 5:
+					if (tag !== 42) {
+						break;
+					}
+
+					message.remaining_balance_commitment = reader.string();
+					continue;
+				case 6:
+					if (tag !== 50) {
+						break;
+					}
+
+					message.proofs = WithdrawMsgProofs.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): WithdrawDecrypted {
+		return {
+			from_address: isSet(object.from_address) ? globalThis.String(object.from_address) : "",
+			denom: isSet(object.denom) ? globalThis.String(object.denom) : "",
+			amount: isSet(object.amount) ? globalThis.String(object.amount) : "",
+			decryptable_balance: isSet(object.decryptable_balance) ? globalThis.String(object.decryptable_balance) : "",
+			remaining_balance_commitment: isSet(object.remaining_balance_commitment) ? globalThis.String(object.remaining_balance_commitment) : "",
+			proofs: isSet(object.proofs) ? WithdrawMsgProofs.fromJSON(object.proofs) : undefined
+		};
+	},
+
+	toJSON(message: WithdrawDecrypted): unknown {
+		const obj: any = {};
+		if (message.from_address !== "") {
+			obj.from_address = message.from_address;
+		}
+		if (message.denom !== "") {
+			obj.denom = message.denom;
+		}
+		if (message.amount !== "") {
+			obj.amount = message.amount;
+		}
+		if (message.decryptable_balance !== "") {
+			obj.decryptable_balance = message.decryptable_balance;
+		}
+		if (message.remaining_balance_commitment !== "") {
+			obj.remaining_balance_commitment = message.remaining_balance_commitment;
+		}
+		if (message.proofs !== undefined) {
+			obj.proofs = WithdrawMsgProofs.toJSON(message.proofs);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<WithdrawDecrypted>, I>>(base?: I): WithdrawDecrypted {
+		return WithdrawDecrypted.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<WithdrawDecrypted>, I>>(object: I): WithdrawDecrypted {
+		const message = createBaseWithdrawDecrypted();
+		message.from_address = object.from_address ?? "";
+		message.denom = object.denom ?? "";
+		message.amount = object.amount ?? "";
+		message.decryptable_balance = object.decryptable_balance ?? "";
+		message.remaining_balance_commitment = object.remaining_balance_commitment ?? "";
+		message.proofs = object.proofs !== undefined && object.proofs !== null ? WithdrawMsgProofs.fromPartial(object.proofs) : undefined;
+		return message;
+	}
+};
+
+export const TransferDecrypted: MessageFns<TransferDecrypted, "seiprotocol.seichain.confidentialtransfers.TransferDecrypted"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.TransferDecrypted" as const,
+
+	encode(message: TransferDecrypted, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.from_address !== "") {
+			writer.uint32(10).string(message.from_address);
+		}
+		if (message.to_address !== "") {
+			writer.uint32(18).string(message.to_address);
+		}
+		if (message.denom !== "") {
+			writer.uint32(26).string(message.denom);
+		}
+		if (message.transfer_amount_lo !== 0) {
+			writer.uint32(32).uint32(message.transfer_amount_lo);
+		}
+		if (message.transfer_amount_hi !== 0) {
+			writer.uint32(40).uint32(message.transfer_amount_hi);
+		}
+		if (message.total_transfer_amount !== 0) {
+			writer.uint32(48).uint64(message.total_transfer_amount);
+		}
+		if (message.remaining_balance_commitment !== "") {
+			writer.uint32(58).string(message.remaining_balance_commitment);
+		}
+		if (message.decryptable_balance !== "") {
+			writer.uint32(66).string(message.decryptable_balance);
+		}
+		if (message.proofs !== undefined) {
+			TransferMsgProofs.encode(message.proofs, writer.uint32(74).fork()).join();
+		}
+		for (const v of message.auditors) {
+			writer.uint32(82).string(v!);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): TransferDecrypted {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseTransferDecrypted();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.from_address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.to_address = reader.string();
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.denom = reader.string();
+					continue;
+				case 4:
+					if (tag !== 32) {
+						break;
+					}
+
+					message.transfer_amount_lo = reader.uint32();
+					continue;
+				case 5:
+					if (tag !== 40) {
+						break;
+					}
+
+					message.transfer_amount_hi = reader.uint32();
+					continue;
+				case 6:
+					if (tag !== 48) {
+						break;
+					}
+
+					message.total_transfer_amount = longToNumber(reader.uint64());
+					continue;
+				case 7:
+					if (tag !== 58) {
+						break;
+					}
+
+					message.remaining_balance_commitment = reader.string();
+					continue;
+				case 8:
+					if (tag !== 66) {
+						break;
+					}
+
+					message.decryptable_balance = reader.string();
+					continue;
+				case 9:
+					if (tag !== 74) {
+						break;
+					}
+
+					message.proofs = TransferMsgProofs.decode(reader, reader.uint32());
+					continue;
+				case 10:
+					if (tag !== 82) {
+						break;
+					}
+
+					message.auditors.push(reader.string());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): TransferDecrypted {
+		return {
+			from_address: isSet(object.from_address) ? globalThis.String(object.from_address) : "",
+			to_address: isSet(object.to_address) ? globalThis.String(object.to_address) : "",
+			denom: isSet(object.denom) ? globalThis.String(object.denom) : "",
+			transfer_amount_lo: isSet(object.transfer_amount_lo) ? globalThis.Number(object.transfer_amount_lo) : 0,
+			transfer_amount_hi: isSet(object.transfer_amount_hi) ? globalThis.Number(object.transfer_amount_hi) : 0,
+			total_transfer_amount: isSet(object.total_transfer_amount) ? globalThis.Number(object.total_transfer_amount) : 0,
+			remaining_balance_commitment: isSet(object.remaining_balance_commitment) ? globalThis.String(object.remaining_balance_commitment) : "",
+			decryptable_balance: isSet(object.decryptable_balance) ? globalThis.String(object.decryptable_balance) : "",
+			proofs: isSet(object.proofs) ? TransferMsgProofs.fromJSON(object.proofs) : undefined,
+			auditors: globalThis.Array.isArray(object?.auditors) ? object.auditors.map((e: any) => globalThis.String(e)) : []
+		};
+	},
+
+	toJSON(message: TransferDecrypted): unknown {
+		const obj: any = {};
+		if (message.from_address !== "") {
+			obj.from_address = message.from_address;
+		}
+		if (message.to_address !== "") {
+			obj.to_address = message.to_address;
+		}
+		if (message.denom !== "") {
+			obj.denom = message.denom;
+		}
+		if (message.transfer_amount_lo !== 0) {
+			obj.transfer_amount_lo = Math.round(message.transfer_amount_lo);
+		}
+		if (message.transfer_amount_hi !== 0) {
+			obj.transfer_amount_hi = Math.round(message.transfer_amount_hi);
+		}
+		if (message.total_transfer_amount !== 0) {
+			obj.total_transfer_amount = Math.round(message.total_transfer_amount);
+		}
+		if (message.remaining_balance_commitment !== "") {
+			obj.remaining_balance_commitment = message.remaining_balance_commitment;
+		}
+		if (message.decryptable_balance !== "") {
+			obj.decryptable_balance = message.decryptable_balance;
+		}
+		if (message.proofs !== undefined) {
+			obj.proofs = TransferMsgProofs.toJSON(message.proofs);
+		}
+		if (message.auditors?.length) {
+			obj.auditors = message.auditors;
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<TransferDecrypted>, I>>(base?: I): TransferDecrypted {
+		return TransferDecrypted.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<TransferDecrypted>, I>>(object: I): TransferDecrypted {
+		const message = createBaseTransferDecrypted();
+		message.from_address = object.from_address ?? "";
+		message.to_address = object.to_address ?? "";
+		message.denom = object.denom ?? "";
+		message.transfer_amount_lo = object.transfer_amount_lo ?? 0;
+		message.transfer_amount_hi = object.transfer_amount_hi ?? 0;
+		message.total_transfer_amount = object.total_transfer_amount ?? 0;
+		message.remaining_balance_commitment = object.remaining_balance_commitment ?? "";
+		message.decryptable_balance = object.decryptable_balance ?? "";
+		message.proofs = object.proofs !== undefined && object.proofs !== null ? TransferMsgProofs.fromPartial(object.proofs) : undefined;
+		message.auditors = object.auditors?.map((e) => e) || [];
+		return message;
+	}
+};
+
+function createBaseGetCtAccountRequest(): GetCtAccountRequest {
+	return { address: "", denom: "" };
+}
+
+function createBaseGetCtAccountResponse(): GetCtAccountResponse {
+	return { account: undefined };
+}
+
+function createBaseGetAllCtAccountsRequest(): GetAllCtAccountsRequest {
+	return { address: "", pagination: undefined };
+}
+
+function createBaseGetAllCtAccountsResponse(): GetAllCtAccountsResponse {
+	return { accounts: [], pagination: undefined };
+}
+
+function createBaseDecryptedCtAccount(): DecryptedCtAccount {
+	return {
+		public_key: new Uint8Array(0),
+		pending_balance_lo: 0,
+		pending_balance_hi: 0,
+		combined_pending_balance: "",
+		pending_balance_credit_counter: 0,
+		available_balance: "",
+		decryptable_available_balance: ""
+	};
+}
+
+function createBaseApplyPendingBalanceDecrypted(): ApplyPendingBalanceDecrypted {
+	return {
+		address: "",
+		denom: "",
+		new_decryptable_available_balance: "",
+		current_pending_balance_counter: 0,
+		current_available_balance: ""
+	};
+}
+
+function createBaseInitializeAccountDecrypted(): InitializeAccountDecrypted {
+	return {
+		from_address: "",
+		denom: "",
+		pubkey: new Uint8Array(0),
+		pending_balance_lo: 0,
+		pending_balance_hi: 0,
+		available_balance: "",
+		decryptable_balance: "",
+		proofs: undefined
+	};
+}
+
+function createBaseWithdrawDecrypted(): WithdrawDecrypted {
+	return {
+		from_address: "",
+		denom: "",
+		amount: "",
+		decryptable_balance: "",
+		remaining_balance_commitment: "",
+		proofs: undefined
+	};
+}
+
+function createBaseTransferDecrypted(): TransferDecrypted {
+	return {
+		from_address: "",
+		to_address: "",
+		denom: "",
+		transfer_amount_lo: 0,
+		transfer_amount_hi: 0,
+		total_transfer_amount: 0,
+		remaining_balance_commitment: "",
+		decryptable_balance: "",
+		proofs: undefined,
+		auditors: []
+	};
+}
+
+function bytesFromBase64(b64: string): Uint8Array {
+	if ((globalThis as any).Buffer) {
+		return Uint8Array.from(globalThis.Buffer.from(b64, "base64"));
+	} else {
+		const bin = globalThis.atob(b64);
+		const arr = new Uint8Array(bin.length);
+		for (let i = 0; i < bin.length; ++i) {
+			arr[i] = bin.charCodeAt(i);
+		}
+		return arr;
+	}
+}
+
+function base64FromBytes(arr: Uint8Array): string {
+	if ((globalThis as any).Buffer) {
+		return globalThis.Buffer.from(arr).toString("base64");
+	} else {
+		const bin: string[] = [];
+		arr.forEach((byte) => {
+			bin.push(globalThis.String.fromCharCode(byte));
+		});
+		return globalThis.btoa(bin.join(""));
+	}
+}
+
+function longToNumber(int64: { toString(): string }): number {
+	const num = globalThis.Number(int64.toString());
+	if (num > globalThis.Number.MAX_SAFE_INTEGER) {
+		throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+	}
+	if (num < globalThis.Number.MIN_SAFE_INTEGER) {
+		throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
+	}
+	return num;
+}
+
+function isSet(value: any): boolean {
+	return value !== null && value !== undefined;
+}

--- a/packages/cosmos/library/encoding/confidentialtransfers/tx.ts
+++ b/packages/cosmos/library/encoding/confidentialtransfers/tx.ts
@@ -1,0 +1,1436 @@
+import type { GeneratedType } from "@cosmjs/proto-signing";
+
+import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+
+import { Ciphertext } from "./cryptography";
+
+import {
+	CiphertextCiphertextEqualityProof,
+	CiphertextValidityProof,
+	CloseAccountMsgProofs,
+	InitializeAccountMsgProofs,
+	TransferMsgProofs,
+	WithdrawMsgProofs
+} from "./zk";
+
+import type {
+	Auditor as Auditor_type,
+	MsgApplyPendingBalanceResponse as MsgApplyPendingBalanceResponse_type,
+	MsgApplyPendingBalance as MsgApplyPendingBalance_type,
+	MsgCloseAccountResponse as MsgCloseAccountResponse_type,
+	MsgCloseAccount as MsgCloseAccount_type,
+	MsgDepositResponse as MsgDepositResponse_type,
+	MsgDeposit as MsgDeposit_type,
+	MsgInitializeAccountResponse as MsgInitializeAccountResponse_type,
+	MsgInitializeAccount as MsgInitializeAccount_type,
+	MsgTransferResponse as MsgTransferResponse_type,
+	MsgTransfer as MsgTransfer_type,
+	MsgWithdrawResponse as MsgWithdrawResponse_type,
+	MsgWithdraw as MsgWithdraw_type
+} from "../../types/confidentialtransfers";
+
+import type { DeepPartial, Exact, MessageFns } from "../common";
+
+export interface MsgTransfer extends MsgTransfer_type {}
+export interface MsgTransferResponse extends MsgTransferResponse_type {}
+export interface Auditor extends Auditor_type {}
+export interface MsgInitializeAccount extends MsgInitializeAccount_type {}
+export interface MsgInitializeAccountResponse extends MsgInitializeAccountResponse_type {}
+export interface MsgDeposit extends MsgDeposit_type {}
+export interface MsgDepositResponse extends MsgDepositResponse_type {}
+export interface MsgWithdraw extends MsgWithdraw_type {}
+export interface MsgWithdrawResponse extends MsgWithdrawResponse_type {}
+export interface MsgApplyPendingBalance extends MsgApplyPendingBalance_type {}
+export interface MsgApplyPendingBalanceResponse extends MsgApplyPendingBalanceResponse_type {}
+export interface MsgCloseAccount extends MsgCloseAccount_type {}
+export interface MsgCloseAccountResponse extends MsgCloseAccountResponse_type {}
+
+export const MsgTransfer: MessageFns<MsgTransfer, "seiprotocol.seichain.confidentialtransfers.MsgTransfer"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.MsgTransfer" as const,
+
+	encode(message: MsgTransfer, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.from_address !== "") {
+			writer.uint32(10).string(message.from_address);
+		}
+		if (message.to_address !== "") {
+			writer.uint32(18).string(message.to_address);
+		}
+		if (message.denom !== "") {
+			writer.uint32(26).string(message.denom);
+		}
+		if (message.from_amount_lo !== undefined) {
+			Ciphertext.encode(message.from_amount_lo, writer.uint32(34).fork()).join();
+		}
+		if (message.from_amount_hi !== undefined) {
+			Ciphertext.encode(message.from_amount_hi, writer.uint32(42).fork()).join();
+		}
+		if (message.to_amount_lo !== undefined) {
+			Ciphertext.encode(message.to_amount_lo, writer.uint32(50).fork()).join();
+		}
+		if (message.to_amount_hi !== undefined) {
+			Ciphertext.encode(message.to_amount_hi, writer.uint32(58).fork()).join();
+		}
+		if (message.remaining_balance !== undefined) {
+			Ciphertext.encode(message.remaining_balance, writer.uint32(66).fork()).join();
+		}
+		if (message.decryptable_balance !== "") {
+			writer.uint32(74).string(message.decryptable_balance);
+		}
+		if (message.proofs !== undefined) {
+			TransferMsgProofs.encode(message.proofs, writer.uint32(82).fork()).join();
+		}
+		for (const v of message.auditors) {
+			Auditor.encode(v!, writer.uint32(90).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): MsgTransfer {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseMsgTransfer();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.from_address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.to_address = reader.string();
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.denom = reader.string();
+					continue;
+				case 4:
+					if (tag !== 34) {
+						break;
+					}
+
+					message.from_amount_lo = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 5:
+					if (tag !== 42) {
+						break;
+					}
+
+					message.from_amount_hi = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 6:
+					if (tag !== 50) {
+						break;
+					}
+
+					message.to_amount_lo = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 7:
+					if (tag !== 58) {
+						break;
+					}
+
+					message.to_amount_hi = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 8:
+					if (tag !== 66) {
+						break;
+					}
+
+					message.remaining_balance = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 9:
+					if (tag !== 74) {
+						break;
+					}
+
+					message.decryptable_balance = reader.string();
+					continue;
+				case 10:
+					if (tag !== 82) {
+						break;
+					}
+
+					message.proofs = TransferMsgProofs.decode(reader, reader.uint32());
+					continue;
+				case 11:
+					if (tag !== 90) {
+						break;
+					}
+
+					message.auditors.push(Auditor.decode(reader, reader.uint32()));
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): MsgTransfer {
+		return {
+			from_address: isSet(object.from_address) ? globalThis.String(object.from_address) : "",
+			to_address: isSet(object.to_address) ? globalThis.String(object.to_address) : "",
+			denom: isSet(object.denom) ? globalThis.String(object.denom) : "",
+			from_amount_lo: isSet(object.from_amount_lo) ? Ciphertext.fromJSON(object.from_amount_lo) : undefined,
+			from_amount_hi: isSet(object.from_amount_hi) ? Ciphertext.fromJSON(object.from_amount_hi) : undefined,
+			to_amount_lo: isSet(object.to_amount_lo) ? Ciphertext.fromJSON(object.to_amount_lo) : undefined,
+			to_amount_hi: isSet(object.to_amount_hi) ? Ciphertext.fromJSON(object.to_amount_hi) : undefined,
+			remaining_balance: isSet(object.remaining_balance) ? Ciphertext.fromJSON(object.remaining_balance) : undefined,
+			decryptable_balance: isSet(object.decryptable_balance) ? globalThis.String(object.decryptable_balance) : "",
+			proofs: isSet(object.proofs) ? TransferMsgProofs.fromJSON(object.proofs) : undefined,
+			auditors: globalThis.Array.isArray(object?.auditors) ? object.auditors.map((e: any) => Auditor.fromJSON(e)) : []
+		};
+	},
+
+	toJSON(message: MsgTransfer): unknown {
+		const obj: any = {};
+		if (message.from_address !== "") {
+			obj.from_address = message.from_address;
+		}
+		if (message.to_address !== "") {
+			obj.to_address = message.to_address;
+		}
+		if (message.denom !== "") {
+			obj.denom = message.denom;
+		}
+		if (message.from_amount_lo !== undefined) {
+			obj.from_amount_lo = Ciphertext.toJSON(message.from_amount_lo);
+		}
+		if (message.from_amount_hi !== undefined) {
+			obj.from_amount_hi = Ciphertext.toJSON(message.from_amount_hi);
+		}
+		if (message.to_amount_lo !== undefined) {
+			obj.to_amount_lo = Ciphertext.toJSON(message.to_amount_lo);
+		}
+		if (message.to_amount_hi !== undefined) {
+			obj.to_amount_hi = Ciphertext.toJSON(message.to_amount_hi);
+		}
+		if (message.remaining_balance !== undefined) {
+			obj.remaining_balance = Ciphertext.toJSON(message.remaining_balance);
+		}
+		if (message.decryptable_balance !== "") {
+			obj.decryptable_balance = message.decryptable_balance;
+		}
+		if (message.proofs !== undefined) {
+			obj.proofs = TransferMsgProofs.toJSON(message.proofs);
+		}
+		if (message.auditors?.length) {
+			obj.auditors = message.auditors.map((e) => Auditor.toJSON(e));
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<MsgTransfer>, I>>(base?: I): MsgTransfer {
+		return MsgTransfer.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<MsgTransfer>, I>>(object: I): MsgTransfer {
+		const message = createBaseMsgTransfer();
+		message.from_address = object.from_address ?? "";
+		message.to_address = object.to_address ?? "";
+		message.denom = object.denom ?? "";
+		message.from_amount_lo = object.from_amount_lo !== undefined && object.from_amount_lo !== null ? Ciphertext.fromPartial(object.from_amount_lo) : undefined;
+		message.from_amount_hi = object.from_amount_hi !== undefined && object.from_amount_hi !== null ? Ciphertext.fromPartial(object.from_amount_hi) : undefined;
+		message.to_amount_lo = object.to_amount_lo !== undefined && object.to_amount_lo !== null ? Ciphertext.fromPartial(object.to_amount_lo) : undefined;
+		message.to_amount_hi = object.to_amount_hi !== undefined && object.to_amount_hi !== null ? Ciphertext.fromPartial(object.to_amount_hi) : undefined;
+		message.remaining_balance =
+			object.remaining_balance !== undefined && object.remaining_balance !== null ? Ciphertext.fromPartial(object.remaining_balance) : undefined;
+		message.decryptable_balance = object.decryptable_balance ?? "";
+		message.proofs = object.proofs !== undefined && object.proofs !== null ? TransferMsgProofs.fromPartial(object.proofs) : undefined;
+		message.auditors = object.auditors?.map((e) => Auditor.fromPartial(e)) || [];
+		return message;
+	}
+};
+
+export const MsgTransferResponse: MessageFns<MsgTransferResponse, "seiprotocol.seichain.confidentialtransfers.MsgTransferResponse"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.MsgTransferResponse" as const,
+
+	encode(_: MsgTransferResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): MsgTransferResponse {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseMsgTransferResponse();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(_: any): MsgTransferResponse {
+		return {};
+	},
+
+	toJSON(_: MsgTransferResponse): unknown {
+		const obj: any = {};
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<MsgTransferResponse>, I>>(base?: I): MsgTransferResponse {
+		return MsgTransferResponse.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<MsgTransferResponse>, I>>(_: I): MsgTransferResponse {
+		const message = createBaseMsgTransferResponse();
+		return message;
+	}
+};
+
+export const Auditor: MessageFns<Auditor, "seiprotocol.seichain.confidentialtransfers.Auditor"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.Auditor" as const,
+
+	encode(message: Auditor, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.auditor_address !== "") {
+			writer.uint32(10).string(message.auditor_address);
+		}
+		if (message.encrypted_transfer_amount_lo !== undefined) {
+			Ciphertext.encode(message.encrypted_transfer_amount_lo, writer.uint32(18).fork()).join();
+		}
+		if (message.encrypted_transfer_amount_hi !== undefined) {
+			Ciphertext.encode(message.encrypted_transfer_amount_hi, writer.uint32(26).fork()).join();
+		}
+		if (message.transfer_amount_lo_validity_proof !== undefined) {
+			CiphertextValidityProof.encode(message.transfer_amount_lo_validity_proof, writer.uint32(34).fork()).join();
+		}
+		if (message.transfer_amount_hi_validity_proof !== undefined) {
+			CiphertextValidityProof.encode(message.transfer_amount_hi_validity_proof, writer.uint32(42).fork()).join();
+		}
+		if (message.transfer_amount_lo_equality_proof !== undefined) {
+			CiphertextCiphertextEqualityProof.encode(message.transfer_amount_lo_equality_proof, writer.uint32(50).fork()).join();
+		}
+		if (message.transfer_amount_hi_equality_proof !== undefined) {
+			CiphertextCiphertextEqualityProof.encode(message.transfer_amount_hi_equality_proof, writer.uint32(58).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): Auditor {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseAuditor();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.auditor_address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.encrypted_transfer_amount_lo = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.encrypted_transfer_amount_hi = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 4:
+					if (tag !== 34) {
+						break;
+					}
+
+					message.transfer_amount_lo_validity_proof = CiphertextValidityProof.decode(reader, reader.uint32());
+					continue;
+				case 5:
+					if (tag !== 42) {
+						break;
+					}
+
+					message.transfer_amount_hi_validity_proof = CiphertextValidityProof.decode(reader, reader.uint32());
+					continue;
+				case 6:
+					if (tag !== 50) {
+						break;
+					}
+
+					message.transfer_amount_lo_equality_proof = CiphertextCiphertextEqualityProof.decode(reader, reader.uint32());
+					continue;
+				case 7:
+					if (tag !== 58) {
+						break;
+					}
+
+					message.transfer_amount_hi_equality_proof = CiphertextCiphertextEqualityProof.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): Auditor {
+		return {
+			auditor_address: isSet(object.auditor_address) ? globalThis.String(object.auditor_address) : "",
+			encrypted_transfer_amount_lo: isSet(object.encrypted_transfer_amount_lo) ? Ciphertext.fromJSON(object.encrypted_transfer_amount_lo) : undefined,
+			encrypted_transfer_amount_hi: isSet(object.encrypted_transfer_amount_hi) ? Ciphertext.fromJSON(object.encrypted_transfer_amount_hi) : undefined,
+			transfer_amount_lo_validity_proof: isSet(object.transfer_amount_lo_validity_proof)
+				? CiphertextValidityProof.fromJSON(object.transfer_amount_lo_validity_proof)
+				: undefined,
+			transfer_amount_hi_validity_proof: isSet(object.transfer_amount_hi_validity_proof)
+				? CiphertextValidityProof.fromJSON(object.transfer_amount_hi_validity_proof)
+				: undefined,
+			transfer_amount_lo_equality_proof: isSet(object.transfer_amount_lo_equality_proof)
+				? CiphertextCiphertextEqualityProof.fromJSON(object.transfer_amount_lo_equality_proof)
+				: undefined,
+			transfer_amount_hi_equality_proof: isSet(object.transfer_amount_hi_equality_proof)
+				? CiphertextCiphertextEqualityProof.fromJSON(object.transfer_amount_hi_equality_proof)
+				: undefined
+		};
+	},
+
+	toJSON(message: Auditor): unknown {
+		const obj: any = {};
+		if (message.auditor_address !== "") {
+			obj.auditor_address = message.auditor_address;
+		}
+		if (message.encrypted_transfer_amount_lo !== undefined) {
+			obj.encrypted_transfer_amount_lo = Ciphertext.toJSON(message.encrypted_transfer_amount_lo);
+		}
+		if (message.encrypted_transfer_amount_hi !== undefined) {
+			obj.encrypted_transfer_amount_hi = Ciphertext.toJSON(message.encrypted_transfer_amount_hi);
+		}
+		if (message.transfer_amount_lo_validity_proof !== undefined) {
+			obj.transfer_amount_lo_validity_proof = CiphertextValidityProof.toJSON(message.transfer_amount_lo_validity_proof);
+		}
+		if (message.transfer_amount_hi_validity_proof !== undefined) {
+			obj.transfer_amount_hi_validity_proof = CiphertextValidityProof.toJSON(message.transfer_amount_hi_validity_proof);
+		}
+		if (message.transfer_amount_lo_equality_proof !== undefined) {
+			obj.transfer_amount_lo_equality_proof = CiphertextCiphertextEqualityProof.toJSON(message.transfer_amount_lo_equality_proof);
+		}
+		if (message.transfer_amount_hi_equality_proof !== undefined) {
+			obj.transfer_amount_hi_equality_proof = CiphertextCiphertextEqualityProof.toJSON(message.transfer_amount_hi_equality_proof);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<Auditor>, I>>(base?: I): Auditor {
+		return Auditor.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<Auditor>, I>>(object: I): Auditor {
+		const message = createBaseAuditor();
+		message.auditor_address = object.auditor_address ?? "";
+		message.encrypted_transfer_amount_lo =
+			object.encrypted_transfer_amount_lo !== undefined && object.encrypted_transfer_amount_lo !== null
+				? Ciphertext.fromPartial(object.encrypted_transfer_amount_lo)
+				: undefined;
+		message.encrypted_transfer_amount_hi =
+			object.encrypted_transfer_amount_hi !== undefined && object.encrypted_transfer_amount_hi !== null
+				? Ciphertext.fromPartial(object.encrypted_transfer_amount_hi)
+				: undefined;
+		message.transfer_amount_lo_validity_proof =
+			object.transfer_amount_lo_validity_proof !== undefined && object.transfer_amount_lo_validity_proof !== null
+				? CiphertextValidityProof.fromPartial(object.transfer_amount_lo_validity_proof)
+				: undefined;
+		message.transfer_amount_hi_validity_proof =
+			object.transfer_amount_hi_validity_proof !== undefined && object.transfer_amount_hi_validity_proof !== null
+				? CiphertextValidityProof.fromPartial(object.transfer_amount_hi_validity_proof)
+				: undefined;
+		message.transfer_amount_lo_equality_proof =
+			object.transfer_amount_lo_equality_proof !== undefined && object.transfer_amount_lo_equality_proof !== null
+				? CiphertextCiphertextEqualityProof.fromPartial(object.transfer_amount_lo_equality_proof)
+				: undefined;
+		message.transfer_amount_hi_equality_proof =
+			object.transfer_amount_hi_equality_proof !== undefined && object.transfer_amount_hi_equality_proof !== null
+				? CiphertextCiphertextEqualityProof.fromPartial(object.transfer_amount_hi_equality_proof)
+				: undefined;
+		return message;
+	}
+};
+
+export const MsgInitializeAccount: MessageFns<MsgInitializeAccount, "seiprotocol.seichain.confidentialtransfers.MsgInitializeAccount"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.MsgInitializeAccount" as const,
+
+	encode(message: MsgInitializeAccount, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.from_address !== "") {
+			writer.uint32(10).string(message.from_address);
+		}
+		if (message.denom !== "") {
+			writer.uint32(18).string(message.denom);
+		}
+		if (message.public_key.length !== 0) {
+			writer.uint32(26).bytes(message.public_key);
+		}
+		if (message.decryptable_balance !== "") {
+			writer.uint32(34).string(message.decryptable_balance);
+		}
+		if (message.pending_balance_lo !== undefined) {
+			Ciphertext.encode(message.pending_balance_lo, writer.uint32(42).fork()).join();
+		}
+		if (message.pending_balance_hi !== undefined) {
+			Ciphertext.encode(message.pending_balance_hi, writer.uint32(50).fork()).join();
+		}
+		if (message.available_balance !== undefined) {
+			Ciphertext.encode(message.available_balance, writer.uint32(58).fork()).join();
+		}
+		if (message.proofs !== undefined) {
+			InitializeAccountMsgProofs.encode(message.proofs, writer.uint32(66).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): MsgInitializeAccount {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseMsgInitializeAccount();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.from_address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.denom = reader.string();
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.public_key = reader.bytes();
+					continue;
+				case 4:
+					if (tag !== 34) {
+						break;
+					}
+
+					message.decryptable_balance = reader.string();
+					continue;
+				case 5:
+					if (tag !== 42) {
+						break;
+					}
+
+					message.pending_balance_lo = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 6:
+					if (tag !== 50) {
+						break;
+					}
+
+					message.pending_balance_hi = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 7:
+					if (tag !== 58) {
+						break;
+					}
+
+					message.available_balance = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 8:
+					if (tag !== 66) {
+						break;
+					}
+
+					message.proofs = InitializeAccountMsgProofs.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): MsgInitializeAccount {
+		return {
+			from_address: isSet(object.from_address) ? globalThis.String(object.from_address) : "",
+			denom: isSet(object.denom) ? globalThis.String(object.denom) : "",
+			public_key: isSet(object.public_key) ? bytesFromBase64(object.public_key) : new Uint8Array(0),
+			decryptable_balance: isSet(object.decryptable_balance) ? globalThis.String(object.decryptable_balance) : "",
+			pending_balance_lo: isSet(object.pending_balance_lo) ? Ciphertext.fromJSON(object.pending_balance_lo) : undefined,
+			pending_balance_hi: isSet(object.pending_balance_hi) ? Ciphertext.fromJSON(object.pending_balance_hi) : undefined,
+			available_balance: isSet(object.available_balance) ? Ciphertext.fromJSON(object.available_balance) : undefined,
+			proofs: isSet(object.proofs) ? InitializeAccountMsgProofs.fromJSON(object.proofs) : undefined
+		};
+	},
+
+	toJSON(message: MsgInitializeAccount): unknown {
+		const obj: any = {};
+		if (message.from_address !== "") {
+			obj.from_address = message.from_address;
+		}
+		if (message.denom !== "") {
+			obj.denom = message.denom;
+		}
+		if (message.public_key.length !== 0) {
+			obj.public_key = base64FromBytes(message.public_key);
+		}
+		if (message.decryptable_balance !== "") {
+			obj.decryptable_balance = message.decryptable_balance;
+		}
+		if (message.pending_balance_lo !== undefined) {
+			obj.pending_balance_lo = Ciphertext.toJSON(message.pending_balance_lo);
+		}
+		if (message.pending_balance_hi !== undefined) {
+			obj.pending_balance_hi = Ciphertext.toJSON(message.pending_balance_hi);
+		}
+		if (message.available_balance !== undefined) {
+			obj.available_balance = Ciphertext.toJSON(message.available_balance);
+		}
+		if (message.proofs !== undefined) {
+			obj.proofs = InitializeAccountMsgProofs.toJSON(message.proofs);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<MsgInitializeAccount>, I>>(base?: I): MsgInitializeAccount {
+		return MsgInitializeAccount.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<MsgInitializeAccount>, I>>(object: I): MsgInitializeAccount {
+		const message = createBaseMsgInitializeAccount();
+		message.from_address = object.from_address ?? "";
+		message.denom = object.denom ?? "";
+		message.public_key = object.public_key ?? new Uint8Array(0);
+		message.decryptable_balance = object.decryptable_balance ?? "";
+		message.pending_balance_lo =
+			object.pending_balance_lo !== undefined && object.pending_balance_lo !== null ? Ciphertext.fromPartial(object.pending_balance_lo) : undefined;
+		message.pending_balance_hi =
+			object.pending_balance_hi !== undefined && object.pending_balance_hi !== null ? Ciphertext.fromPartial(object.pending_balance_hi) : undefined;
+		message.available_balance =
+			object.available_balance !== undefined && object.available_balance !== null ? Ciphertext.fromPartial(object.available_balance) : undefined;
+		message.proofs = object.proofs !== undefined && object.proofs !== null ? InitializeAccountMsgProofs.fromPartial(object.proofs) : undefined;
+		return message;
+	}
+};
+
+export const MsgInitializeAccountResponse: MessageFns<MsgInitializeAccountResponse, "seiprotocol.seichain.confidentialtransfers.MsgInitializeAccountResponse"> =
+	{
+		$type: "seiprotocol.seichain.confidentialtransfers.MsgInitializeAccountResponse" as const,
+
+		encode(_: MsgInitializeAccountResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+			return writer;
+		},
+
+		decode(input: BinaryReader | Uint8Array, length?: number): MsgInitializeAccountResponse {
+			const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+			const end = length === undefined ? reader.len : reader.pos + length;
+			const message = createBaseMsgInitializeAccountResponse();
+			while (reader.pos < end) {
+				const tag = reader.uint32();
+				switch (tag >>> 3) {
+				}
+				if ((tag & 7) === 4 || tag === 0) {
+					break;
+				}
+				reader.skip(tag & 7);
+			}
+			return message;
+		},
+
+		fromJSON(_: any): MsgInitializeAccountResponse {
+			return {};
+		},
+
+		toJSON(_: MsgInitializeAccountResponse): unknown {
+			const obj: any = {};
+			return obj;
+		},
+
+		create<I extends Exact<DeepPartial<MsgInitializeAccountResponse>, I>>(base?: I): MsgInitializeAccountResponse {
+			return MsgInitializeAccountResponse.fromPartial(base ?? ({} as any));
+		},
+		fromPartial<I extends Exact<DeepPartial<MsgInitializeAccountResponse>, I>>(_: I): MsgInitializeAccountResponse {
+			const message = createBaseMsgInitializeAccountResponse();
+			return message;
+		}
+	};
+
+export const MsgDeposit: MessageFns<MsgDeposit, "seiprotocol.seichain.confidentialtransfers.MsgDeposit"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.MsgDeposit" as const,
+
+	encode(message: MsgDeposit, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.from_address !== "") {
+			writer.uint32(10).string(message.from_address);
+		}
+		if (message.denom !== "") {
+			writer.uint32(18).string(message.denom);
+		}
+		if (message.amount !== 0) {
+			writer.uint32(24).uint64(message.amount);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): MsgDeposit {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseMsgDeposit();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.from_address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.denom = reader.string();
+					continue;
+				case 3:
+					if (tag !== 24) {
+						break;
+					}
+
+					message.amount = longToNumber(reader.uint64());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): MsgDeposit {
+		return {
+			from_address: isSet(object.from_address) ? globalThis.String(object.from_address) : "",
+			denom: isSet(object.denom) ? globalThis.String(object.denom) : "",
+			amount: isSet(object.amount) ? globalThis.Number(object.amount) : 0
+		};
+	},
+
+	toJSON(message: MsgDeposit): unknown {
+		const obj: any = {};
+		if (message.from_address !== "") {
+			obj.from_address = message.from_address;
+		}
+		if (message.denom !== "") {
+			obj.denom = message.denom;
+		}
+		if (message.amount !== 0) {
+			obj.amount = Math.round(message.amount);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<MsgDeposit>, I>>(base?: I): MsgDeposit {
+		return MsgDeposit.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<MsgDeposit>, I>>(object: I): MsgDeposit {
+		const message = createBaseMsgDeposit();
+		message.from_address = object.from_address ?? "";
+		message.denom = object.denom ?? "";
+		message.amount = object.amount ?? 0;
+		return message;
+	}
+};
+
+export const MsgDepositResponse: MessageFns<MsgDepositResponse, "seiprotocol.seichain.confidentialtransfers.MsgDepositResponse"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.MsgDepositResponse" as const,
+
+	encode(_: MsgDepositResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): MsgDepositResponse {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseMsgDepositResponse();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(_: any): MsgDepositResponse {
+		return {};
+	},
+
+	toJSON(_: MsgDepositResponse): unknown {
+		const obj: any = {};
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<MsgDepositResponse>, I>>(base?: I): MsgDepositResponse {
+		return MsgDepositResponse.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<MsgDepositResponse>, I>>(_: I): MsgDepositResponse {
+		const message = createBaseMsgDepositResponse();
+		return message;
+	}
+};
+
+export const MsgWithdraw: MessageFns<MsgWithdraw, "seiprotocol.seichain.confidentialtransfers.MsgWithdraw"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.MsgWithdraw" as const,
+
+	encode(message: MsgWithdraw, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.from_address !== "") {
+			writer.uint32(10).string(message.from_address);
+		}
+		if (message.denom !== "") {
+			writer.uint32(18).string(message.denom);
+		}
+		if (message.amount !== "") {
+			writer.uint32(26).string(message.amount);
+		}
+		if (message.decryptable_balance !== "") {
+			writer.uint32(34).string(message.decryptable_balance);
+		}
+		if (message.remaining_balance_commitment !== undefined) {
+			Ciphertext.encode(message.remaining_balance_commitment, writer.uint32(42).fork()).join();
+		}
+		if (message.proofs !== undefined) {
+			WithdrawMsgProofs.encode(message.proofs, writer.uint32(50).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): MsgWithdraw {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseMsgWithdraw();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.from_address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.denom = reader.string();
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.amount = reader.string();
+					continue;
+				case 4:
+					if (tag !== 34) {
+						break;
+					}
+
+					message.decryptable_balance = reader.string();
+					continue;
+				case 5:
+					if (tag !== 42) {
+						break;
+					}
+
+					message.remaining_balance_commitment = Ciphertext.decode(reader, reader.uint32());
+					continue;
+				case 6:
+					if (tag !== 50) {
+						break;
+					}
+
+					message.proofs = WithdrawMsgProofs.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): MsgWithdraw {
+		return {
+			from_address: isSet(object.from_address) ? globalThis.String(object.from_address) : "",
+			denom: isSet(object.denom) ? globalThis.String(object.denom) : "",
+			amount: isSet(object.amount) ? globalThis.String(object.amount) : "",
+			decryptable_balance: isSet(object.decryptable_balance) ? globalThis.String(object.decryptable_balance) : "",
+			remaining_balance_commitment: isSet(object.remaining_balance_commitment) ? Ciphertext.fromJSON(object.remaining_balance_commitment) : undefined,
+			proofs: isSet(object.proofs) ? WithdrawMsgProofs.fromJSON(object.proofs) : undefined
+		};
+	},
+
+	toJSON(message: MsgWithdraw): unknown {
+		const obj: any = {};
+		if (message.from_address !== "") {
+			obj.from_address = message.from_address;
+		}
+		if (message.denom !== "") {
+			obj.denom = message.denom;
+		}
+		if (message.amount !== "") {
+			obj.amount = message.amount;
+		}
+		if (message.decryptable_balance !== "") {
+			obj.decryptable_balance = message.decryptable_balance;
+		}
+		if (message.remaining_balance_commitment !== undefined) {
+			obj.remaining_balance_commitment = Ciphertext.toJSON(message.remaining_balance_commitment);
+		}
+		if (message.proofs !== undefined) {
+			obj.proofs = WithdrawMsgProofs.toJSON(message.proofs);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<MsgWithdraw>, I>>(base?: I): MsgWithdraw {
+		return MsgWithdraw.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<MsgWithdraw>, I>>(object: I): MsgWithdraw {
+		const message = createBaseMsgWithdraw();
+		message.from_address = object.from_address ?? "";
+		message.denom = object.denom ?? "";
+		message.amount = object.amount ?? "";
+		message.decryptable_balance = object.decryptable_balance ?? "";
+		message.remaining_balance_commitment =
+			object.remaining_balance_commitment !== undefined && object.remaining_balance_commitment !== null
+				? Ciphertext.fromPartial(object.remaining_balance_commitment)
+				: undefined;
+		message.proofs = object.proofs !== undefined && object.proofs !== null ? WithdrawMsgProofs.fromPartial(object.proofs) : undefined;
+		return message;
+	}
+};
+
+export const MsgWithdrawResponse: MessageFns<MsgWithdrawResponse, "seiprotocol.seichain.confidentialtransfers.MsgWithdrawResponse"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.MsgWithdrawResponse" as const,
+
+	encode(_: MsgWithdrawResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): MsgWithdrawResponse {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseMsgWithdrawResponse();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(_: any): MsgWithdrawResponse {
+		return {};
+	},
+
+	toJSON(_: MsgWithdrawResponse): unknown {
+		const obj: any = {};
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<MsgWithdrawResponse>, I>>(base?: I): MsgWithdrawResponse {
+		return MsgWithdrawResponse.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<MsgWithdrawResponse>, I>>(_: I): MsgWithdrawResponse {
+		const message = createBaseMsgWithdrawResponse();
+		return message;
+	}
+};
+
+export const MsgApplyPendingBalance: MessageFns<MsgApplyPendingBalance, "seiprotocol.seichain.confidentialtransfers.MsgApplyPendingBalance"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.MsgApplyPendingBalance" as const,
+
+	encode(message: MsgApplyPendingBalance, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.address !== "") {
+			writer.uint32(10).string(message.address);
+		}
+		if (message.denom !== "") {
+			writer.uint32(18).string(message.denom);
+		}
+		if (message.new_decryptable_available_balance !== "") {
+			writer.uint32(26).string(message.new_decryptable_available_balance);
+		}
+		if (message.current_pending_balance_counter !== 0) {
+			writer.uint32(32).uint32(message.current_pending_balance_counter);
+		}
+		if (message.current_available_balance !== undefined) {
+			Ciphertext.encode(message.current_available_balance, writer.uint32(42).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): MsgApplyPendingBalance {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseMsgApplyPendingBalance();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.denom = reader.string();
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.new_decryptable_available_balance = reader.string();
+					continue;
+				case 4:
+					if (tag !== 32) {
+						break;
+					}
+
+					message.current_pending_balance_counter = reader.uint32();
+					continue;
+				case 5:
+					if (tag !== 42) {
+						break;
+					}
+
+					message.current_available_balance = Ciphertext.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): MsgApplyPendingBalance {
+		return {
+			address: isSet(object.address) ? globalThis.String(object.address) : "",
+			denom: isSet(object.denom) ? globalThis.String(object.denom) : "",
+			new_decryptable_available_balance: isSet(object.new_decryptable_available_balance) ? globalThis.String(object.new_decryptable_available_balance) : "",
+			current_pending_balance_counter: isSet(object.current_pending_balance_counter) ? globalThis.Number(object.current_pending_balance_counter) : 0,
+			current_available_balance: isSet(object.current_available_balance) ? Ciphertext.fromJSON(object.current_available_balance) : undefined
+		};
+	},
+
+	toJSON(message: MsgApplyPendingBalance): unknown {
+		const obj: any = {};
+		if (message.address !== "") {
+			obj.address = message.address;
+		}
+		if (message.denom !== "") {
+			obj.denom = message.denom;
+		}
+		if (message.new_decryptable_available_balance !== "") {
+			obj.new_decryptable_available_balance = message.new_decryptable_available_balance;
+		}
+		if (message.current_pending_balance_counter !== 0) {
+			obj.current_pending_balance_counter = Math.round(message.current_pending_balance_counter);
+		}
+		if (message.current_available_balance !== undefined) {
+			obj.current_available_balance = Ciphertext.toJSON(message.current_available_balance);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<MsgApplyPendingBalance>, I>>(base?: I): MsgApplyPendingBalance {
+		return MsgApplyPendingBalance.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<MsgApplyPendingBalance>, I>>(object: I): MsgApplyPendingBalance {
+		const message = createBaseMsgApplyPendingBalance();
+		message.address = object.address ?? "";
+		message.denom = object.denom ?? "";
+		message.new_decryptable_available_balance = object.new_decryptable_available_balance ?? "";
+		message.current_pending_balance_counter = object.current_pending_balance_counter ?? 0;
+		message.current_available_balance =
+			object.current_available_balance !== undefined && object.current_available_balance !== null
+				? Ciphertext.fromPartial(object.current_available_balance)
+				: undefined;
+		return message;
+	}
+};
+
+export const MsgApplyPendingBalanceResponse: MessageFns<
+	MsgApplyPendingBalanceResponse,
+	"seiprotocol.seichain.confidentialtransfers.MsgApplyPendingBalanceResponse"
+> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.MsgApplyPendingBalanceResponse" as const,
+
+	encode(_: MsgApplyPendingBalanceResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): MsgApplyPendingBalanceResponse {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseMsgApplyPendingBalanceResponse();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(_: any): MsgApplyPendingBalanceResponse {
+		return {};
+	},
+
+	toJSON(_: MsgApplyPendingBalanceResponse): unknown {
+		const obj: any = {};
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<MsgApplyPendingBalanceResponse>, I>>(base?: I): MsgApplyPendingBalanceResponse {
+		return MsgApplyPendingBalanceResponse.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<MsgApplyPendingBalanceResponse>, I>>(_: I): MsgApplyPendingBalanceResponse {
+		const message = createBaseMsgApplyPendingBalanceResponse();
+		return message;
+	}
+};
+
+export const MsgCloseAccount: MessageFns<MsgCloseAccount, "seiprotocol.seichain.confidentialtransfers.MsgCloseAccount"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.MsgCloseAccount" as const,
+
+	encode(message: MsgCloseAccount, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.address !== "") {
+			writer.uint32(10).string(message.address);
+		}
+		if (message.denom !== "") {
+			writer.uint32(18).string(message.denom);
+		}
+		if (message.proofs !== undefined) {
+			CloseAccountMsgProofs.encode(message.proofs, writer.uint32(26).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): MsgCloseAccount {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseMsgCloseAccount();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.address = reader.string();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.denom = reader.string();
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.proofs = CloseAccountMsgProofs.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): MsgCloseAccount {
+		return {
+			address: isSet(object.address) ? globalThis.String(object.address) : "",
+			denom: isSet(object.denom) ? globalThis.String(object.denom) : "",
+			proofs: isSet(object.proofs) ? CloseAccountMsgProofs.fromJSON(object.proofs) : undefined
+		};
+	},
+
+	toJSON(message: MsgCloseAccount): unknown {
+		const obj: any = {};
+		if (message.address !== "") {
+			obj.address = message.address;
+		}
+		if (message.denom !== "") {
+			obj.denom = message.denom;
+		}
+		if (message.proofs !== undefined) {
+			obj.proofs = CloseAccountMsgProofs.toJSON(message.proofs);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<MsgCloseAccount>, I>>(base?: I): MsgCloseAccount {
+		return MsgCloseAccount.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<MsgCloseAccount>, I>>(object: I): MsgCloseAccount {
+		const message = createBaseMsgCloseAccount();
+		message.address = object.address ?? "";
+		message.denom = object.denom ?? "";
+		message.proofs = object.proofs !== undefined && object.proofs !== null ? CloseAccountMsgProofs.fromPartial(object.proofs) : undefined;
+		return message;
+	}
+};
+
+export const MsgCloseAccountResponse: MessageFns<MsgCloseAccountResponse, "seiprotocol.seichain.confidentialtransfers.MsgCloseAccountResponse"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.MsgCloseAccountResponse" as const,
+
+	encode(_: MsgCloseAccountResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): MsgCloseAccountResponse {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseMsgCloseAccountResponse();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(_: any): MsgCloseAccountResponse {
+		return {};
+	},
+
+	toJSON(_: MsgCloseAccountResponse): unknown {
+		const obj: any = {};
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<MsgCloseAccountResponse>, I>>(base?: I): MsgCloseAccountResponse {
+		return MsgCloseAccountResponse.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<MsgCloseAccountResponse>, I>>(_: I): MsgCloseAccountResponse {
+		const message = createBaseMsgCloseAccountResponse();
+		return message;
+	}
+};
+
+function createBaseMsgTransfer(): MsgTransfer {
+	return {
+		from_address: "",
+		to_address: "",
+		denom: "",
+		from_amount_lo: undefined,
+		from_amount_hi: undefined,
+		to_amount_lo: undefined,
+		to_amount_hi: undefined,
+		remaining_balance: undefined,
+		decryptable_balance: "",
+		proofs: undefined,
+		auditors: []
+	};
+}
+
+function createBaseMsgTransferResponse(): MsgTransferResponse {
+	return {};
+}
+
+function createBaseAuditor(): Auditor {
+	return {
+		auditor_address: "",
+		encrypted_transfer_amount_lo: undefined,
+		encrypted_transfer_amount_hi: undefined,
+		transfer_amount_lo_validity_proof: undefined,
+		transfer_amount_hi_validity_proof: undefined,
+		transfer_amount_lo_equality_proof: undefined,
+		transfer_amount_hi_equality_proof: undefined
+	};
+}
+
+function createBaseMsgInitializeAccount(): MsgInitializeAccount {
+	return {
+		from_address: "",
+		denom: "",
+		public_key: new Uint8Array(0),
+		decryptable_balance: "",
+		pending_balance_lo: undefined,
+		pending_balance_hi: undefined,
+		available_balance: undefined,
+		proofs: undefined
+	};
+}
+
+function createBaseMsgInitializeAccountResponse(): MsgInitializeAccountResponse {
+	return {};
+}
+
+function createBaseMsgDeposit(): MsgDeposit {
+	return { from_address: "", denom: "", amount: 0 };
+}
+
+function createBaseMsgDepositResponse(): MsgDepositResponse {
+	return {};
+}
+
+function createBaseMsgWithdraw(): MsgWithdraw {
+	return {
+		from_address: "",
+		denom: "",
+		amount: "",
+		decryptable_balance: "",
+		remaining_balance_commitment: undefined,
+		proofs: undefined
+	};
+}
+
+function createBaseMsgWithdrawResponse(): MsgWithdrawResponse {
+	return {};
+}
+
+function createBaseMsgApplyPendingBalance(): MsgApplyPendingBalance {
+	return {
+		address: "",
+		denom: "",
+		new_decryptable_available_balance: "",
+		current_pending_balance_counter: 0,
+		current_available_balance: undefined
+	};
+}
+
+function createBaseMsgApplyPendingBalanceResponse(): MsgApplyPendingBalanceResponse {
+	return {};
+}
+
+function createBaseMsgCloseAccount(): MsgCloseAccount {
+	return { address: "", denom: "", proofs: undefined };
+}
+
+function createBaseMsgCloseAccountResponse(): MsgCloseAccountResponse {
+	return {};
+}
+
+function bytesFromBase64(b64: string): Uint8Array {
+	if ((globalThis as any).Buffer) {
+		return Uint8Array.from(globalThis.Buffer.from(b64, "base64"));
+	} else {
+		const bin = globalThis.atob(b64);
+		const arr = new Uint8Array(bin.length);
+		for (let i = 0; i < bin.length; ++i) {
+			arr[i] = bin.charCodeAt(i);
+		}
+		return arr;
+	}
+}
+
+function base64FromBytes(arr: Uint8Array): string {
+	if ((globalThis as any).Buffer) {
+		return globalThis.Buffer.from(arr).toString("base64");
+	} else {
+		const bin: string[] = [];
+		arr.forEach((byte) => {
+			bin.push(globalThis.String.fromCharCode(byte));
+		});
+		return globalThis.btoa(bin.join(""));
+	}
+}
+
+function longToNumber(int64: { toString(): string }): number {
+	const num = globalThis.Number(int64.toString());
+	if (num > globalThis.Number.MAX_SAFE_INTEGER) {
+		throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+	}
+	if (num < globalThis.Number.MIN_SAFE_INTEGER) {
+		throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
+	}
+	return num;
+}
+
+function isSet(value: any): boolean {
+	return value !== null && value !== undefined;
+}
+export const registry: Array<[string, GeneratedType]> = [
+	["/seiprotocol.seichain.confidentialtransfers.MsgTransfer", MsgTransfer as never],
+	["/seiprotocol.seichain.confidentialtransfers.Auditor", Auditor as never],
+	["/seiprotocol.seichain.confidentialtransfers.MsgDeposit", MsgDeposit as never],
+	["/seiprotocol.seichain.confidentialtransfers.MsgWithdraw", MsgWithdraw as never]
+];
+export const aminoConverters = {
+	"/seiprotocol.seichain.confidentialtransfers.MsgTransfer": {
+		aminoType: "confidentialtransfers/MsgTransfer",
+		toAmino: (message: MsgTransfer) => ({ ...message }),
+		fromAmino: (object: MsgTransfer) => ({ ...object })
+	},
+
+	"/seiprotocol.seichain.confidentialtransfers.Auditor": {
+		aminoType: "confidentialtransfers/Auditor",
+		toAmino: (message: Auditor) => ({ ...message }),
+		fromAmino: (object: Auditor) => ({ ...object })
+	},
+
+	"/seiprotocol.seichain.confidentialtransfers.MsgDeposit": {
+		aminoType: "confidentialtransfers/MsgDeposit",
+		toAmino: (message: MsgDeposit) => ({ ...message }),
+		fromAmino: (object: MsgDeposit) => ({ ...object })
+	},
+
+	"/seiprotocol.seichain.confidentialtransfers.MsgWithdraw": {
+		aminoType: "confidentialtransfers/MsgWithdraw",
+		toAmino: (message: MsgWithdraw) => ({ ...message }),
+		fromAmino: (object: MsgWithdraw) => ({ ...object })
+	}
+};

--- a/packages/cosmos/library/encoding/confidentialtransfers/zk.ts
+++ b/packages/cosmos/library/encoding/confidentialtransfers/zk.ts
@@ -1,0 +1,1337 @@
+import type { GeneratedType } from "@cosmjs/proto-signing";
+
+import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+
+import type {
+	CiphertextCiphertextEqualityProof as CiphertextCiphertextEqualityProof_type,
+	CiphertextCommitmentEqualityProof as CiphertextCommitmentEqualityProof_type,
+	CiphertextValidityProof as CiphertextValidityProof_type,
+	CloseAccountMsgProofs as CloseAccountMsgProofs_type,
+	InitializeAccountMsgProofs as InitializeAccountMsgProofs_type,
+	PubkeyValidityProof as PubkeyValidityProof_type,
+	RangeProof as RangeProof_type,
+	TransferMsgProofs as TransferMsgProofs_type,
+	WithdrawMsgProofs as WithdrawMsgProofs_type,
+	ZeroBalanceProof as ZeroBalanceProof_type
+} from "../../types/confidentialtransfers";
+
+import type { DeepPartial, Exact, MessageFns } from "../common";
+
+export interface TransferMsgProofs extends TransferMsgProofs_type {}
+export interface InitializeAccountMsgProofs extends InitializeAccountMsgProofs_type {}
+export interface WithdrawMsgProofs extends WithdrawMsgProofs_type {}
+export interface CloseAccountMsgProofs extends CloseAccountMsgProofs_type {}
+export interface PubkeyValidityProof extends PubkeyValidityProof_type {}
+export interface CiphertextValidityProof extends CiphertextValidityProof_type {}
+export interface RangeProof extends RangeProof_type {}
+export interface CiphertextCommitmentEqualityProof extends CiphertextCommitmentEqualityProof_type {}
+export interface CiphertextCiphertextEqualityProof extends CiphertextCiphertextEqualityProof_type {}
+export interface ZeroBalanceProof extends ZeroBalanceProof_type {}
+
+export const TransferMsgProofs: MessageFns<TransferMsgProofs, "seiprotocol.seichain.confidentialtransfers.TransferMsgProofs"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.TransferMsgProofs" as const,
+
+	encode(message: TransferMsgProofs, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.remaining_balance_commitment_validity_proof !== undefined) {
+			CiphertextValidityProof.encode(message.remaining_balance_commitment_validity_proof, writer.uint32(10).fork()).join();
+		}
+		if (message.sender_transfer_amount_lo_validity_proof !== undefined) {
+			CiphertextValidityProof.encode(message.sender_transfer_amount_lo_validity_proof, writer.uint32(18).fork()).join();
+		}
+		if (message.sender_transfer_amount_hi_validity_proof !== undefined) {
+			CiphertextValidityProof.encode(message.sender_transfer_amount_hi_validity_proof, writer.uint32(26).fork()).join();
+		}
+		if (message.recipient_transfer_amount_lo_validity_proof !== undefined) {
+			CiphertextValidityProof.encode(message.recipient_transfer_amount_lo_validity_proof, writer.uint32(34).fork()).join();
+		}
+		if (message.recipient_transfer_amount_hi_validity_proof !== undefined) {
+			CiphertextValidityProof.encode(message.recipient_transfer_amount_hi_validity_proof, writer.uint32(42).fork()).join();
+		}
+		if (message.remaining_balance_range_proof !== undefined) {
+			RangeProof.encode(message.remaining_balance_range_proof, writer.uint32(50).fork()).join();
+		}
+		if (message.remaining_balance_equality_proof !== undefined) {
+			CiphertextCommitmentEqualityProof.encode(message.remaining_balance_equality_proof, writer.uint32(58).fork()).join();
+		}
+		if (message.transfer_amount_lo_equality_proof !== undefined) {
+			CiphertextCiphertextEqualityProof.encode(message.transfer_amount_lo_equality_proof, writer.uint32(66).fork()).join();
+		}
+		if (message.transfer_amount_hi_equality_proof !== undefined) {
+			CiphertextCiphertextEqualityProof.encode(message.transfer_amount_hi_equality_proof, writer.uint32(74).fork()).join();
+		}
+		if (message.transfer_amount_lo_range_proof !== undefined) {
+			RangeProof.encode(message.transfer_amount_lo_range_proof, writer.uint32(82).fork()).join();
+		}
+		if (message.transfer_amount_hi_range_proof !== undefined) {
+			RangeProof.encode(message.transfer_amount_hi_range_proof, writer.uint32(90).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): TransferMsgProofs {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseTransferMsgProofs();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.remaining_balance_commitment_validity_proof = CiphertextValidityProof.decode(reader, reader.uint32());
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.sender_transfer_amount_lo_validity_proof = CiphertextValidityProof.decode(reader, reader.uint32());
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.sender_transfer_amount_hi_validity_proof = CiphertextValidityProof.decode(reader, reader.uint32());
+					continue;
+				case 4:
+					if (tag !== 34) {
+						break;
+					}
+
+					message.recipient_transfer_amount_lo_validity_proof = CiphertextValidityProof.decode(reader, reader.uint32());
+					continue;
+				case 5:
+					if (tag !== 42) {
+						break;
+					}
+
+					message.recipient_transfer_amount_hi_validity_proof = CiphertextValidityProof.decode(reader, reader.uint32());
+					continue;
+				case 6:
+					if (tag !== 50) {
+						break;
+					}
+
+					message.remaining_balance_range_proof = RangeProof.decode(reader, reader.uint32());
+					continue;
+				case 7:
+					if (tag !== 58) {
+						break;
+					}
+
+					message.remaining_balance_equality_proof = CiphertextCommitmentEqualityProof.decode(reader, reader.uint32());
+					continue;
+				case 8:
+					if (tag !== 66) {
+						break;
+					}
+
+					message.transfer_amount_lo_equality_proof = CiphertextCiphertextEqualityProof.decode(reader, reader.uint32());
+					continue;
+				case 9:
+					if (tag !== 74) {
+						break;
+					}
+
+					message.transfer_amount_hi_equality_proof = CiphertextCiphertextEqualityProof.decode(reader, reader.uint32());
+					continue;
+				case 10:
+					if (tag !== 82) {
+						break;
+					}
+
+					message.transfer_amount_lo_range_proof = RangeProof.decode(reader, reader.uint32());
+					continue;
+				case 11:
+					if (tag !== 90) {
+						break;
+					}
+
+					message.transfer_amount_hi_range_proof = RangeProof.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): TransferMsgProofs {
+		return {
+			remaining_balance_commitment_validity_proof: isSet(object.remaining_balance_commitment_validity_proof)
+				? CiphertextValidityProof.fromJSON(object.remaining_balance_commitment_validity_proof)
+				: undefined,
+			sender_transfer_amount_lo_validity_proof: isSet(object.sender_transfer_amount_lo_validity_proof)
+				? CiphertextValidityProof.fromJSON(object.sender_transfer_amount_lo_validity_proof)
+				: undefined,
+			sender_transfer_amount_hi_validity_proof: isSet(object.sender_transfer_amount_hi_validity_proof)
+				? CiphertextValidityProof.fromJSON(object.sender_transfer_amount_hi_validity_proof)
+				: undefined,
+			recipient_transfer_amount_lo_validity_proof: isSet(object.recipient_transfer_amount_lo_validity_proof)
+				? CiphertextValidityProof.fromJSON(object.recipient_transfer_amount_lo_validity_proof)
+				: undefined,
+			recipient_transfer_amount_hi_validity_proof: isSet(object.recipient_transfer_amount_hi_validity_proof)
+				? CiphertextValidityProof.fromJSON(object.recipient_transfer_amount_hi_validity_proof)
+				: undefined,
+			remaining_balance_range_proof: isSet(object.remaining_balance_range_proof) ? RangeProof.fromJSON(object.remaining_balance_range_proof) : undefined,
+			remaining_balance_equality_proof: isSet(object.remaining_balance_equality_proof)
+				? CiphertextCommitmentEqualityProof.fromJSON(object.remaining_balance_equality_proof)
+				: undefined,
+			transfer_amount_lo_equality_proof: isSet(object.transfer_amount_lo_equality_proof)
+				? CiphertextCiphertextEqualityProof.fromJSON(object.transfer_amount_lo_equality_proof)
+				: undefined,
+			transfer_amount_hi_equality_proof: isSet(object.transfer_amount_hi_equality_proof)
+				? CiphertextCiphertextEqualityProof.fromJSON(object.transfer_amount_hi_equality_proof)
+				: undefined,
+			transfer_amount_lo_range_proof: isSet(object.transfer_amount_lo_range_proof) ? RangeProof.fromJSON(object.transfer_amount_lo_range_proof) : undefined,
+			transfer_amount_hi_range_proof: isSet(object.transfer_amount_hi_range_proof) ? RangeProof.fromJSON(object.transfer_amount_hi_range_proof) : undefined
+		};
+	},
+
+	toJSON(message: TransferMsgProofs): unknown {
+		const obj: any = {};
+		if (message.remaining_balance_commitment_validity_proof !== undefined) {
+			obj.remaining_balance_commitment_validity_proof = CiphertextValidityProof.toJSON(message.remaining_balance_commitment_validity_proof);
+		}
+		if (message.sender_transfer_amount_lo_validity_proof !== undefined) {
+			obj.sender_transfer_amount_lo_validity_proof = CiphertextValidityProof.toJSON(message.sender_transfer_amount_lo_validity_proof);
+		}
+		if (message.sender_transfer_amount_hi_validity_proof !== undefined) {
+			obj.sender_transfer_amount_hi_validity_proof = CiphertextValidityProof.toJSON(message.sender_transfer_amount_hi_validity_proof);
+		}
+		if (message.recipient_transfer_amount_lo_validity_proof !== undefined) {
+			obj.recipient_transfer_amount_lo_validity_proof = CiphertextValidityProof.toJSON(message.recipient_transfer_amount_lo_validity_proof);
+		}
+		if (message.recipient_transfer_amount_hi_validity_proof !== undefined) {
+			obj.recipient_transfer_amount_hi_validity_proof = CiphertextValidityProof.toJSON(message.recipient_transfer_amount_hi_validity_proof);
+		}
+		if (message.remaining_balance_range_proof !== undefined) {
+			obj.remaining_balance_range_proof = RangeProof.toJSON(message.remaining_balance_range_proof);
+		}
+		if (message.remaining_balance_equality_proof !== undefined) {
+			obj.remaining_balance_equality_proof = CiphertextCommitmentEqualityProof.toJSON(message.remaining_balance_equality_proof);
+		}
+		if (message.transfer_amount_lo_equality_proof !== undefined) {
+			obj.transfer_amount_lo_equality_proof = CiphertextCiphertextEqualityProof.toJSON(message.transfer_amount_lo_equality_proof);
+		}
+		if (message.transfer_amount_hi_equality_proof !== undefined) {
+			obj.transfer_amount_hi_equality_proof = CiphertextCiphertextEqualityProof.toJSON(message.transfer_amount_hi_equality_proof);
+		}
+		if (message.transfer_amount_lo_range_proof !== undefined) {
+			obj.transfer_amount_lo_range_proof = RangeProof.toJSON(message.transfer_amount_lo_range_proof);
+		}
+		if (message.transfer_amount_hi_range_proof !== undefined) {
+			obj.transfer_amount_hi_range_proof = RangeProof.toJSON(message.transfer_amount_hi_range_proof);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<TransferMsgProofs>, I>>(base?: I): TransferMsgProofs {
+		return TransferMsgProofs.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<TransferMsgProofs>, I>>(object: I): TransferMsgProofs {
+		const message = createBaseTransferMsgProofs();
+		message.remaining_balance_commitment_validity_proof =
+			object.remaining_balance_commitment_validity_proof !== undefined && object.remaining_balance_commitment_validity_proof !== null
+				? CiphertextValidityProof.fromPartial(object.remaining_balance_commitment_validity_proof)
+				: undefined;
+		message.sender_transfer_amount_lo_validity_proof =
+			object.sender_transfer_amount_lo_validity_proof !== undefined && object.sender_transfer_amount_lo_validity_proof !== null
+				? CiphertextValidityProof.fromPartial(object.sender_transfer_amount_lo_validity_proof)
+				: undefined;
+		message.sender_transfer_amount_hi_validity_proof =
+			object.sender_transfer_amount_hi_validity_proof !== undefined && object.sender_transfer_amount_hi_validity_proof !== null
+				? CiphertextValidityProof.fromPartial(object.sender_transfer_amount_hi_validity_proof)
+				: undefined;
+		message.recipient_transfer_amount_lo_validity_proof =
+			object.recipient_transfer_amount_lo_validity_proof !== undefined && object.recipient_transfer_amount_lo_validity_proof !== null
+				? CiphertextValidityProof.fromPartial(object.recipient_transfer_amount_lo_validity_proof)
+				: undefined;
+		message.recipient_transfer_amount_hi_validity_proof =
+			object.recipient_transfer_amount_hi_validity_proof !== undefined && object.recipient_transfer_amount_hi_validity_proof !== null
+				? CiphertextValidityProof.fromPartial(object.recipient_transfer_amount_hi_validity_proof)
+				: undefined;
+		message.remaining_balance_range_proof =
+			object.remaining_balance_range_proof !== undefined && object.remaining_balance_range_proof !== null
+				? RangeProof.fromPartial(object.remaining_balance_range_proof)
+				: undefined;
+		message.remaining_balance_equality_proof =
+			object.remaining_balance_equality_proof !== undefined && object.remaining_balance_equality_proof !== null
+				? CiphertextCommitmentEqualityProof.fromPartial(object.remaining_balance_equality_proof)
+				: undefined;
+		message.transfer_amount_lo_equality_proof =
+			object.transfer_amount_lo_equality_proof !== undefined && object.transfer_amount_lo_equality_proof !== null
+				? CiphertextCiphertextEqualityProof.fromPartial(object.transfer_amount_lo_equality_proof)
+				: undefined;
+		message.transfer_amount_hi_equality_proof =
+			object.transfer_amount_hi_equality_proof !== undefined && object.transfer_amount_hi_equality_proof !== null
+				? CiphertextCiphertextEqualityProof.fromPartial(object.transfer_amount_hi_equality_proof)
+				: undefined;
+		message.transfer_amount_lo_range_proof =
+			object.transfer_amount_lo_range_proof !== undefined && object.transfer_amount_lo_range_proof !== null
+				? RangeProof.fromPartial(object.transfer_amount_lo_range_proof)
+				: undefined;
+		message.transfer_amount_hi_range_proof =
+			object.transfer_amount_hi_range_proof !== undefined && object.transfer_amount_hi_range_proof !== null
+				? RangeProof.fromPartial(object.transfer_amount_hi_range_proof)
+				: undefined;
+		return message;
+	}
+};
+
+export const InitializeAccountMsgProofs: MessageFns<InitializeAccountMsgProofs, "seiprotocol.seichain.confidentialtransfers.InitializeAccountMsgProofs"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.InitializeAccountMsgProofs" as const,
+
+	encode(message: InitializeAccountMsgProofs, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.pubkey_validity_proof !== undefined) {
+			PubkeyValidityProof.encode(message.pubkey_validity_proof, writer.uint32(10).fork()).join();
+		}
+		if (message.zero_pending_balance_lo_proof !== undefined) {
+			ZeroBalanceProof.encode(message.zero_pending_balance_lo_proof, writer.uint32(18).fork()).join();
+		}
+		if (message.zero_pending_balance_hi_proof !== undefined) {
+			ZeroBalanceProof.encode(message.zero_pending_balance_hi_proof, writer.uint32(26).fork()).join();
+		}
+		if (message.zero_available_balance_proof !== undefined) {
+			ZeroBalanceProof.encode(message.zero_available_balance_proof, writer.uint32(34).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): InitializeAccountMsgProofs {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseInitializeAccountMsgProofs();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.pubkey_validity_proof = PubkeyValidityProof.decode(reader, reader.uint32());
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.zero_pending_balance_lo_proof = ZeroBalanceProof.decode(reader, reader.uint32());
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.zero_pending_balance_hi_proof = ZeroBalanceProof.decode(reader, reader.uint32());
+					continue;
+				case 4:
+					if (tag !== 34) {
+						break;
+					}
+
+					message.zero_available_balance_proof = ZeroBalanceProof.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): InitializeAccountMsgProofs {
+		return {
+			pubkey_validity_proof: isSet(object.pubkey_validity_proof) ? PubkeyValidityProof.fromJSON(object.pubkey_validity_proof) : undefined,
+			zero_pending_balance_lo_proof: isSet(object.zero_pending_balance_lo_proof) ? ZeroBalanceProof.fromJSON(object.zero_pending_balance_lo_proof) : undefined,
+			zero_pending_balance_hi_proof: isSet(object.zero_pending_balance_hi_proof) ? ZeroBalanceProof.fromJSON(object.zero_pending_balance_hi_proof) : undefined,
+			zero_available_balance_proof: isSet(object.zero_available_balance_proof) ? ZeroBalanceProof.fromJSON(object.zero_available_balance_proof) : undefined
+		};
+	},
+
+	toJSON(message: InitializeAccountMsgProofs): unknown {
+		const obj: any = {};
+		if (message.pubkey_validity_proof !== undefined) {
+			obj.pubkey_validity_proof = PubkeyValidityProof.toJSON(message.pubkey_validity_proof);
+		}
+		if (message.zero_pending_balance_lo_proof !== undefined) {
+			obj.zero_pending_balance_lo_proof = ZeroBalanceProof.toJSON(message.zero_pending_balance_lo_proof);
+		}
+		if (message.zero_pending_balance_hi_proof !== undefined) {
+			obj.zero_pending_balance_hi_proof = ZeroBalanceProof.toJSON(message.zero_pending_balance_hi_proof);
+		}
+		if (message.zero_available_balance_proof !== undefined) {
+			obj.zero_available_balance_proof = ZeroBalanceProof.toJSON(message.zero_available_balance_proof);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<InitializeAccountMsgProofs>, I>>(base?: I): InitializeAccountMsgProofs {
+		return InitializeAccountMsgProofs.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<InitializeAccountMsgProofs>, I>>(object: I): InitializeAccountMsgProofs {
+		const message = createBaseInitializeAccountMsgProofs();
+		message.pubkey_validity_proof =
+			object.pubkey_validity_proof !== undefined && object.pubkey_validity_proof !== null
+				? PubkeyValidityProof.fromPartial(object.pubkey_validity_proof)
+				: undefined;
+		message.zero_pending_balance_lo_proof =
+			object.zero_pending_balance_lo_proof !== undefined && object.zero_pending_balance_lo_proof !== null
+				? ZeroBalanceProof.fromPartial(object.zero_pending_balance_lo_proof)
+				: undefined;
+		message.zero_pending_balance_hi_proof =
+			object.zero_pending_balance_hi_proof !== undefined && object.zero_pending_balance_hi_proof !== null
+				? ZeroBalanceProof.fromPartial(object.zero_pending_balance_hi_proof)
+				: undefined;
+		message.zero_available_balance_proof =
+			object.zero_available_balance_proof !== undefined && object.zero_available_balance_proof !== null
+				? ZeroBalanceProof.fromPartial(object.zero_available_balance_proof)
+				: undefined;
+		return message;
+	}
+};
+
+export const WithdrawMsgProofs: MessageFns<WithdrawMsgProofs, "seiprotocol.seichain.confidentialtransfers.WithdrawMsgProofs"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.WithdrawMsgProofs" as const,
+
+	encode(message: WithdrawMsgProofs, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.remaining_balance_range_proof !== undefined) {
+			RangeProof.encode(message.remaining_balance_range_proof, writer.uint32(10).fork()).join();
+		}
+		if (message.remaining_balance_equality_proof !== undefined) {
+			CiphertextCommitmentEqualityProof.encode(message.remaining_balance_equality_proof, writer.uint32(18).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): WithdrawMsgProofs {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseWithdrawMsgProofs();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.remaining_balance_range_proof = RangeProof.decode(reader, reader.uint32());
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.remaining_balance_equality_proof = CiphertextCommitmentEqualityProof.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): WithdrawMsgProofs {
+		return {
+			remaining_balance_range_proof: isSet(object.remaining_balance_range_proof) ? RangeProof.fromJSON(object.remaining_balance_range_proof) : undefined,
+			remaining_balance_equality_proof: isSet(object.remaining_balance_equality_proof)
+				? CiphertextCommitmentEqualityProof.fromJSON(object.remaining_balance_equality_proof)
+				: undefined
+		};
+	},
+
+	toJSON(message: WithdrawMsgProofs): unknown {
+		const obj: any = {};
+		if (message.remaining_balance_range_proof !== undefined) {
+			obj.remaining_balance_range_proof = RangeProof.toJSON(message.remaining_balance_range_proof);
+		}
+		if (message.remaining_balance_equality_proof !== undefined) {
+			obj.remaining_balance_equality_proof = CiphertextCommitmentEqualityProof.toJSON(message.remaining_balance_equality_proof);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<WithdrawMsgProofs>, I>>(base?: I): WithdrawMsgProofs {
+		return WithdrawMsgProofs.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<WithdrawMsgProofs>, I>>(object: I): WithdrawMsgProofs {
+		const message = createBaseWithdrawMsgProofs();
+		message.remaining_balance_range_proof =
+			object.remaining_balance_range_proof !== undefined && object.remaining_balance_range_proof !== null
+				? RangeProof.fromPartial(object.remaining_balance_range_proof)
+				: undefined;
+		message.remaining_balance_equality_proof =
+			object.remaining_balance_equality_proof !== undefined && object.remaining_balance_equality_proof !== null
+				? CiphertextCommitmentEqualityProof.fromPartial(object.remaining_balance_equality_proof)
+				: undefined;
+		return message;
+	}
+};
+
+export const CloseAccountMsgProofs: MessageFns<CloseAccountMsgProofs, "seiprotocol.seichain.confidentialtransfers.CloseAccountMsgProofs"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.CloseAccountMsgProofs" as const,
+
+	encode(message: CloseAccountMsgProofs, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.zero_available_balance_proof !== undefined) {
+			ZeroBalanceProof.encode(message.zero_available_balance_proof, writer.uint32(10).fork()).join();
+		}
+		if (message.zero_pending_balance_lo_proof !== undefined) {
+			ZeroBalanceProof.encode(message.zero_pending_balance_lo_proof, writer.uint32(18).fork()).join();
+		}
+		if (message.zero_pending_balance_hi_proof !== undefined) {
+			ZeroBalanceProof.encode(message.zero_pending_balance_hi_proof, writer.uint32(26).fork()).join();
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): CloseAccountMsgProofs {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseCloseAccountMsgProofs();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.zero_available_balance_proof = ZeroBalanceProof.decode(reader, reader.uint32());
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.zero_pending_balance_lo_proof = ZeroBalanceProof.decode(reader, reader.uint32());
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.zero_pending_balance_hi_proof = ZeroBalanceProof.decode(reader, reader.uint32());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): CloseAccountMsgProofs {
+		return {
+			zero_available_balance_proof: isSet(object.zero_available_balance_proof) ? ZeroBalanceProof.fromJSON(object.zero_available_balance_proof) : undefined,
+			zero_pending_balance_lo_proof: isSet(object.zero_pending_balance_lo_proof) ? ZeroBalanceProof.fromJSON(object.zero_pending_balance_lo_proof) : undefined,
+			zero_pending_balance_hi_proof: isSet(object.zero_pending_balance_hi_proof) ? ZeroBalanceProof.fromJSON(object.zero_pending_balance_hi_proof) : undefined
+		};
+	},
+
+	toJSON(message: CloseAccountMsgProofs): unknown {
+		const obj: any = {};
+		if (message.zero_available_balance_proof !== undefined) {
+			obj.zero_available_balance_proof = ZeroBalanceProof.toJSON(message.zero_available_balance_proof);
+		}
+		if (message.zero_pending_balance_lo_proof !== undefined) {
+			obj.zero_pending_balance_lo_proof = ZeroBalanceProof.toJSON(message.zero_pending_balance_lo_proof);
+		}
+		if (message.zero_pending_balance_hi_proof !== undefined) {
+			obj.zero_pending_balance_hi_proof = ZeroBalanceProof.toJSON(message.zero_pending_balance_hi_proof);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<CloseAccountMsgProofs>, I>>(base?: I): CloseAccountMsgProofs {
+		return CloseAccountMsgProofs.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<CloseAccountMsgProofs>, I>>(object: I): CloseAccountMsgProofs {
+		const message = createBaseCloseAccountMsgProofs();
+		message.zero_available_balance_proof =
+			object.zero_available_balance_proof !== undefined && object.zero_available_balance_proof !== null
+				? ZeroBalanceProof.fromPartial(object.zero_available_balance_proof)
+				: undefined;
+		message.zero_pending_balance_lo_proof =
+			object.zero_pending_balance_lo_proof !== undefined && object.zero_pending_balance_lo_proof !== null
+				? ZeroBalanceProof.fromPartial(object.zero_pending_balance_lo_proof)
+				: undefined;
+		message.zero_pending_balance_hi_proof =
+			object.zero_pending_balance_hi_proof !== undefined && object.zero_pending_balance_hi_proof !== null
+				? ZeroBalanceProof.fromPartial(object.zero_pending_balance_hi_proof)
+				: undefined;
+		return message;
+	}
+};
+
+export const PubkeyValidityProof: MessageFns<PubkeyValidityProof, "seiprotocol.seichain.confidentialtransfers.PubkeyValidityProof"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.PubkeyValidityProof" as const,
+
+	encode(message: PubkeyValidityProof, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.y.length !== 0) {
+			writer.uint32(10).bytes(message.y);
+		}
+		if (message.z.length !== 0) {
+			writer.uint32(18).bytes(message.z);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): PubkeyValidityProof {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBasePubkeyValidityProof();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.y = reader.bytes();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.z = reader.bytes();
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): PubkeyValidityProof {
+		return {
+			y: isSet(object.y) ? bytesFromBase64(object.y) : new Uint8Array(0),
+			z: isSet(object.z) ? bytesFromBase64(object.z) : new Uint8Array(0)
+		};
+	},
+
+	toJSON(message: PubkeyValidityProof): unknown {
+		const obj: any = {};
+		if (message.y.length !== 0) {
+			obj.y = base64FromBytes(message.y);
+		}
+		if (message.z.length !== 0) {
+			obj.z = base64FromBytes(message.z);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<PubkeyValidityProof>, I>>(base?: I): PubkeyValidityProof {
+		return PubkeyValidityProof.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<PubkeyValidityProof>, I>>(object: I): PubkeyValidityProof {
+		const message = createBasePubkeyValidityProof();
+		message.y = object.y ?? new Uint8Array(0);
+		message.z = object.z ?? new Uint8Array(0);
+		return message;
+	}
+};
+
+export const CiphertextValidityProof: MessageFns<CiphertextValidityProof, "seiprotocol.seichain.confidentialtransfers.CiphertextValidityProof"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.CiphertextValidityProof" as const,
+
+	encode(message: CiphertextValidityProof, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.commitment_1.length !== 0) {
+			writer.uint32(10).bytes(message.commitment_1);
+		}
+		if (message.commitment_2.length !== 0) {
+			writer.uint32(18).bytes(message.commitment_2);
+		}
+		if (message.response_1.length !== 0) {
+			writer.uint32(34).bytes(message.response_1);
+		}
+		if (message.response_2.length !== 0) {
+			writer.uint32(42).bytes(message.response_2);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): CiphertextValidityProof {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseCiphertextValidityProof();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.commitment_1 = reader.bytes();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.commitment_2 = reader.bytes();
+					continue;
+				case 4:
+					if (tag !== 34) {
+						break;
+					}
+
+					message.response_1 = reader.bytes();
+					continue;
+				case 5:
+					if (tag !== 42) {
+						break;
+					}
+
+					message.response_2 = reader.bytes();
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): CiphertextValidityProof {
+		return {
+			commitment_1: isSet(object.commitment_1) ? bytesFromBase64(object.commitment_1) : new Uint8Array(0),
+			commitment_2: isSet(object.commitment_2) ? bytesFromBase64(object.commitment_2) : new Uint8Array(0),
+			response_1: isSet(object.response_1) ? bytesFromBase64(object.response_1) : new Uint8Array(0),
+			response_2: isSet(object.response_2) ? bytesFromBase64(object.response_2) : new Uint8Array(0)
+		};
+	},
+
+	toJSON(message: CiphertextValidityProof): unknown {
+		const obj: any = {};
+		if (message.commitment_1.length !== 0) {
+			obj.commitment_1 = base64FromBytes(message.commitment_1);
+		}
+		if (message.commitment_2.length !== 0) {
+			obj.commitment_2 = base64FromBytes(message.commitment_2);
+		}
+		if (message.response_1.length !== 0) {
+			obj.response_1 = base64FromBytes(message.response_1);
+		}
+		if (message.response_2.length !== 0) {
+			obj.response_2 = base64FromBytes(message.response_2);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<CiphertextValidityProof>, I>>(base?: I): CiphertextValidityProof {
+		return CiphertextValidityProof.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<CiphertextValidityProof>, I>>(object: I): CiphertextValidityProof {
+		const message = createBaseCiphertextValidityProof();
+		message.commitment_1 = object.commitment_1 ?? new Uint8Array(0);
+		message.commitment_2 = object.commitment_2 ?? new Uint8Array(0);
+		message.response_1 = object.response_1 ?? new Uint8Array(0);
+		message.response_2 = object.response_2 ?? new Uint8Array(0);
+		return message;
+	}
+};
+
+export const RangeProof: MessageFns<RangeProof, "seiprotocol.seichain.confidentialtransfers.RangeProof"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.RangeProof" as const,
+
+	encode(message: RangeProof, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.proof.length !== 0) {
+			writer.uint32(10).bytes(message.proof);
+		}
+		if (message.randomness.length !== 0) {
+			writer.uint32(18).bytes(message.randomness);
+		}
+		if (message.upper_bound !== 0) {
+			writer.uint32(24).int64(message.upper_bound);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): RangeProof {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseRangeProof();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.proof = reader.bytes();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.randomness = reader.bytes();
+					continue;
+				case 3:
+					if (tag !== 24) {
+						break;
+					}
+
+					message.upper_bound = longToNumber(reader.int64());
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): RangeProof {
+		return {
+			proof: isSet(object.proof) ? bytesFromBase64(object.proof) : new Uint8Array(0),
+			randomness: isSet(object.randomness) ? bytesFromBase64(object.randomness) : new Uint8Array(0),
+			upper_bound: isSet(object.upper_bound) ? globalThis.Number(object.upper_bound) : 0
+		};
+	},
+
+	toJSON(message: RangeProof): unknown {
+		const obj: any = {};
+		if (message.proof.length !== 0) {
+			obj.proof = base64FromBytes(message.proof);
+		}
+		if (message.randomness.length !== 0) {
+			obj.randomness = base64FromBytes(message.randomness);
+		}
+		if (message.upper_bound !== 0) {
+			obj.upper_bound = Math.round(message.upper_bound);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<RangeProof>, I>>(base?: I): RangeProof {
+		return RangeProof.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<RangeProof>, I>>(object: I): RangeProof {
+		const message = createBaseRangeProof();
+		message.proof = object.proof ?? new Uint8Array(0);
+		message.randomness = object.randomness ?? new Uint8Array(0);
+		message.upper_bound = object.upper_bound ?? 0;
+		return message;
+	}
+};
+
+export const CiphertextCommitmentEqualityProof: MessageFns<
+	CiphertextCommitmentEqualityProof,
+	"seiprotocol.seichain.confidentialtransfers.CiphertextCommitmentEqualityProof"
+> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.CiphertextCommitmentEqualityProof" as const,
+
+	encode(message: CiphertextCommitmentEqualityProof, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.y0.length !== 0) {
+			writer.uint32(10).bytes(message.y0);
+		}
+		if (message.y1.length !== 0) {
+			writer.uint32(18).bytes(message.y1);
+		}
+		if (message.y2.length !== 0) {
+			writer.uint32(26).bytes(message.y2);
+		}
+		if (message.zs.length !== 0) {
+			writer.uint32(34).bytes(message.zs);
+		}
+		if (message.zx.length !== 0) {
+			writer.uint32(42).bytes(message.zx);
+		}
+		if (message.zr.length !== 0) {
+			writer.uint32(50).bytes(message.zr);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): CiphertextCommitmentEqualityProof {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseCiphertextCommitmentEqualityProof();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.y0 = reader.bytes();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.y1 = reader.bytes();
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.y2 = reader.bytes();
+					continue;
+				case 4:
+					if (tag !== 34) {
+						break;
+					}
+
+					message.zs = reader.bytes();
+					continue;
+				case 5:
+					if (tag !== 42) {
+						break;
+					}
+
+					message.zx = reader.bytes();
+					continue;
+				case 6:
+					if (tag !== 50) {
+						break;
+					}
+
+					message.zr = reader.bytes();
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): CiphertextCommitmentEqualityProof {
+		return {
+			y0: isSet(object.y0) ? bytesFromBase64(object.y0) : new Uint8Array(0),
+			y1: isSet(object.y1) ? bytesFromBase64(object.y1) : new Uint8Array(0),
+			y2: isSet(object.y2) ? bytesFromBase64(object.y2) : new Uint8Array(0),
+			zs: isSet(object.zs) ? bytesFromBase64(object.zs) : new Uint8Array(0),
+			zx: isSet(object.zx) ? bytesFromBase64(object.zx) : new Uint8Array(0),
+			zr: isSet(object.zr) ? bytesFromBase64(object.zr) : new Uint8Array(0)
+		};
+	},
+
+	toJSON(message: CiphertextCommitmentEqualityProof): unknown {
+		const obj: any = {};
+		if (message.y0.length !== 0) {
+			obj.y0 = base64FromBytes(message.y0);
+		}
+		if (message.y1.length !== 0) {
+			obj.y1 = base64FromBytes(message.y1);
+		}
+		if (message.y2.length !== 0) {
+			obj.y2 = base64FromBytes(message.y2);
+		}
+		if (message.zs.length !== 0) {
+			obj.zs = base64FromBytes(message.zs);
+		}
+		if (message.zx.length !== 0) {
+			obj.zx = base64FromBytes(message.zx);
+		}
+		if (message.zr.length !== 0) {
+			obj.zr = base64FromBytes(message.zr);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<CiphertextCommitmentEqualityProof>, I>>(base?: I): CiphertextCommitmentEqualityProof {
+		return CiphertextCommitmentEqualityProof.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<CiphertextCommitmentEqualityProof>, I>>(object: I): CiphertextCommitmentEqualityProof {
+		const message = createBaseCiphertextCommitmentEqualityProof();
+		message.y0 = object.y0 ?? new Uint8Array(0);
+		message.y1 = object.y1 ?? new Uint8Array(0);
+		message.y2 = object.y2 ?? new Uint8Array(0);
+		message.zs = object.zs ?? new Uint8Array(0);
+		message.zx = object.zx ?? new Uint8Array(0);
+		message.zr = object.zr ?? new Uint8Array(0);
+		return message;
+	}
+};
+
+export const CiphertextCiphertextEqualityProof: MessageFns<
+	CiphertextCiphertextEqualityProof,
+	"seiprotocol.seichain.confidentialtransfers.CiphertextCiphertextEqualityProof"
+> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.CiphertextCiphertextEqualityProof" as const,
+
+	encode(message: CiphertextCiphertextEqualityProof, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.y0.length !== 0) {
+			writer.uint32(10).bytes(message.y0);
+		}
+		if (message.y1.length !== 0) {
+			writer.uint32(18).bytes(message.y1);
+		}
+		if (message.y2.length !== 0) {
+			writer.uint32(26).bytes(message.y2);
+		}
+		if (message.y3.length !== 0) {
+			writer.uint32(34).bytes(message.y3);
+		}
+		if (message.zs.length !== 0) {
+			writer.uint32(42).bytes(message.zs);
+		}
+		if (message.zx.length !== 0) {
+			writer.uint32(50).bytes(message.zx);
+		}
+		if (message.zr.length !== 0) {
+			writer.uint32(58).bytes(message.zr);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): CiphertextCiphertextEqualityProof {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseCiphertextCiphertextEqualityProof();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.y0 = reader.bytes();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.y1 = reader.bytes();
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.y2 = reader.bytes();
+					continue;
+				case 4:
+					if (tag !== 34) {
+						break;
+					}
+
+					message.y3 = reader.bytes();
+					continue;
+				case 5:
+					if (tag !== 42) {
+						break;
+					}
+
+					message.zs = reader.bytes();
+					continue;
+				case 6:
+					if (tag !== 50) {
+						break;
+					}
+
+					message.zx = reader.bytes();
+					continue;
+				case 7:
+					if (tag !== 58) {
+						break;
+					}
+
+					message.zr = reader.bytes();
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): CiphertextCiphertextEqualityProof {
+		return {
+			y0: isSet(object.y0) ? bytesFromBase64(object.y0) : new Uint8Array(0),
+			y1: isSet(object.y1) ? bytesFromBase64(object.y1) : new Uint8Array(0),
+			y2: isSet(object.y2) ? bytesFromBase64(object.y2) : new Uint8Array(0),
+			y3: isSet(object.y3) ? bytesFromBase64(object.y3) : new Uint8Array(0),
+			zs: isSet(object.zs) ? bytesFromBase64(object.zs) : new Uint8Array(0),
+			zx: isSet(object.zx) ? bytesFromBase64(object.zx) : new Uint8Array(0),
+			zr: isSet(object.zr) ? bytesFromBase64(object.zr) : new Uint8Array(0)
+		};
+	},
+
+	toJSON(message: CiphertextCiphertextEqualityProof): unknown {
+		const obj: any = {};
+		if (message.y0.length !== 0) {
+			obj.y0 = base64FromBytes(message.y0);
+		}
+		if (message.y1.length !== 0) {
+			obj.y1 = base64FromBytes(message.y1);
+		}
+		if (message.y2.length !== 0) {
+			obj.y2 = base64FromBytes(message.y2);
+		}
+		if (message.y3.length !== 0) {
+			obj.y3 = base64FromBytes(message.y3);
+		}
+		if (message.zs.length !== 0) {
+			obj.zs = base64FromBytes(message.zs);
+		}
+		if (message.zx.length !== 0) {
+			obj.zx = base64FromBytes(message.zx);
+		}
+		if (message.zr.length !== 0) {
+			obj.zr = base64FromBytes(message.zr);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<CiphertextCiphertextEqualityProof>, I>>(base?: I): CiphertextCiphertextEqualityProof {
+		return CiphertextCiphertextEqualityProof.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<CiphertextCiphertextEqualityProof>, I>>(object: I): CiphertextCiphertextEqualityProof {
+		const message = createBaseCiphertextCiphertextEqualityProof();
+		message.y0 = object.y0 ?? new Uint8Array(0);
+		message.y1 = object.y1 ?? new Uint8Array(0);
+		message.y2 = object.y2 ?? new Uint8Array(0);
+		message.y3 = object.y3 ?? new Uint8Array(0);
+		message.zs = object.zs ?? new Uint8Array(0);
+		message.zx = object.zx ?? new Uint8Array(0);
+		message.zr = object.zr ?? new Uint8Array(0);
+		return message;
+	}
+};
+
+export const ZeroBalanceProof: MessageFns<ZeroBalanceProof, "seiprotocol.seichain.confidentialtransfers.ZeroBalanceProof"> = {
+	$type: "seiprotocol.seichain.confidentialtransfers.ZeroBalanceProof" as const,
+
+	encode(message: ZeroBalanceProof, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.y_p.length !== 0) {
+			writer.uint32(10).bytes(message.y_p);
+		}
+		if (message.y_d.length !== 0) {
+			writer.uint32(18).bytes(message.y_d);
+		}
+		if (message.z.length !== 0) {
+			writer.uint32(26).bytes(message.z);
+		}
+		return writer;
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): ZeroBalanceProof {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+		const end = length === undefined ? reader.len : reader.pos + length;
+		const message = createBaseZeroBalanceProof();
+		while (reader.pos < end) {
+			const tag = reader.uint32();
+			switch (tag >>> 3) {
+				case 1:
+					if (tag !== 10) {
+						break;
+					}
+
+					message.y_p = reader.bytes();
+					continue;
+				case 2:
+					if (tag !== 18) {
+						break;
+					}
+
+					message.y_d = reader.bytes();
+					continue;
+				case 3:
+					if (tag !== 26) {
+						break;
+					}
+
+					message.z = reader.bytes();
+					continue;
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break;
+			}
+			reader.skip(tag & 7);
+		}
+		return message;
+	},
+
+	fromJSON(object: any): ZeroBalanceProof {
+		return {
+			y_p: isSet(object.y_p) ? bytesFromBase64(object.y_p) : new Uint8Array(0),
+			y_d: isSet(object.y_d) ? bytesFromBase64(object.y_d) : new Uint8Array(0),
+			z: isSet(object.z) ? bytesFromBase64(object.z) : new Uint8Array(0)
+		};
+	},
+
+	toJSON(message: ZeroBalanceProof): unknown {
+		const obj: any = {};
+		if (message.y_p.length !== 0) {
+			obj.y_p = base64FromBytes(message.y_p);
+		}
+		if (message.y_d.length !== 0) {
+			obj.y_d = base64FromBytes(message.y_d);
+		}
+		if (message.z.length !== 0) {
+			obj.z = base64FromBytes(message.z);
+		}
+		return obj;
+	},
+
+	create<I extends Exact<DeepPartial<ZeroBalanceProof>, I>>(base?: I): ZeroBalanceProof {
+		return ZeroBalanceProof.fromPartial(base ?? ({} as any));
+	},
+	fromPartial<I extends Exact<DeepPartial<ZeroBalanceProof>, I>>(object: I): ZeroBalanceProof {
+		const message = createBaseZeroBalanceProof();
+		message.y_p = object.y_p ?? new Uint8Array(0);
+		message.y_d = object.y_d ?? new Uint8Array(0);
+		message.z = object.z ?? new Uint8Array(0);
+		return message;
+	}
+};
+
+function createBaseTransferMsgProofs(): TransferMsgProofs {
+	return {
+		remaining_balance_commitment_validity_proof: undefined,
+		sender_transfer_amount_lo_validity_proof: undefined,
+		sender_transfer_amount_hi_validity_proof: undefined,
+		recipient_transfer_amount_lo_validity_proof: undefined,
+		recipient_transfer_amount_hi_validity_proof: undefined,
+		remaining_balance_range_proof: undefined,
+		remaining_balance_equality_proof: undefined,
+		transfer_amount_lo_equality_proof: undefined,
+		transfer_amount_hi_equality_proof: undefined,
+		transfer_amount_lo_range_proof: undefined,
+		transfer_amount_hi_range_proof: undefined
+	};
+}
+
+function createBaseInitializeAccountMsgProofs(): InitializeAccountMsgProofs {
+	return {
+		pubkey_validity_proof: undefined,
+		zero_pending_balance_lo_proof: undefined,
+		zero_pending_balance_hi_proof: undefined,
+		zero_available_balance_proof: undefined
+	};
+}
+
+function createBaseWithdrawMsgProofs(): WithdrawMsgProofs {
+	return { remaining_balance_range_proof: undefined, remaining_balance_equality_proof: undefined };
+}
+
+function createBaseCloseAccountMsgProofs(): CloseAccountMsgProofs {
+	return {
+		zero_available_balance_proof: undefined,
+		zero_pending_balance_lo_proof: undefined,
+		zero_pending_balance_hi_proof: undefined
+	};
+}
+
+function createBasePubkeyValidityProof(): PubkeyValidityProof {
+	return { y: new Uint8Array(0), z: new Uint8Array(0) };
+}
+
+function createBaseCiphertextValidityProof(): CiphertextValidityProof {
+	return {
+		commitment_1: new Uint8Array(0),
+		commitment_2: new Uint8Array(0),
+		response_1: new Uint8Array(0),
+		response_2: new Uint8Array(0)
+	};
+}
+
+function createBaseRangeProof(): RangeProof {
+	return { proof: new Uint8Array(0), randomness: new Uint8Array(0), upper_bound: 0 };
+}
+
+function createBaseCiphertextCommitmentEqualityProof(): CiphertextCommitmentEqualityProof {
+	return {
+		y0: new Uint8Array(0),
+		y1: new Uint8Array(0),
+		y2: new Uint8Array(0),
+		zs: new Uint8Array(0),
+		zx: new Uint8Array(0),
+		zr: new Uint8Array(0)
+	};
+}
+
+function createBaseCiphertextCiphertextEqualityProof(): CiphertextCiphertextEqualityProof {
+	return {
+		y0: new Uint8Array(0),
+		y1: new Uint8Array(0),
+		y2: new Uint8Array(0),
+		y3: new Uint8Array(0),
+		zs: new Uint8Array(0),
+		zx: new Uint8Array(0),
+		zr: new Uint8Array(0)
+	};
+}
+
+function createBaseZeroBalanceProof(): ZeroBalanceProof {
+	return { y_p: new Uint8Array(0), y_d: new Uint8Array(0), z: new Uint8Array(0) };
+}
+
+function bytesFromBase64(b64: string): Uint8Array {
+	if ((globalThis as any).Buffer) {
+		return Uint8Array.from(globalThis.Buffer.from(b64, "base64"));
+	} else {
+		const bin = globalThis.atob(b64);
+		const arr = new Uint8Array(bin.length);
+		for (let i = 0; i < bin.length; ++i) {
+			arr[i] = bin.charCodeAt(i);
+		}
+		return arr;
+	}
+}
+
+function base64FromBytes(arr: Uint8Array): string {
+	if ((globalThis as any).Buffer) {
+		return globalThis.Buffer.from(arr).toString("base64");
+	} else {
+		const bin: string[] = [];
+		arr.forEach((byte) => {
+			bin.push(globalThis.String.fromCharCode(byte));
+		});
+		return globalThis.btoa(bin.join(""));
+	}
+}
+
+function longToNumber(int64: { toString(): string }): number {
+	const num = globalThis.Number(int64.toString());
+	if (num > globalThis.Number.MAX_SAFE_INTEGER) {
+		throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+	}
+	if (num < globalThis.Number.MIN_SAFE_INTEGER) {
+		throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
+	}
+	return num;
+}
+
+function isSet(value: any): boolean {
+	return value !== null && value !== undefined;
+}
+export const registry: Array<[string, GeneratedType]> = [["/seiprotocol.seichain.confidentialtransfers.RangeProof", RangeProof as never]];
+export const aminoConverters = {
+	"/seiprotocol.seichain.confidentialtransfers.RangeProof": {
+		aminoType: "confidentialtransfers/RangeProof",
+		toAmino: (message: RangeProof) => ({ ...message }),
+		fromAmino: (object: RangeProof) => ({ ...object })
+	}
+};

--- a/packages/cosmos/library/encoding/index.ts
+++ b/packages/cosmos/library/encoding/index.ts
@@ -1,3 +1,4 @@
+import * as confidentialtransfers from "./confidentialtransfers/index";
 import * as confio from "./confio/index";
 import * as cosmos_accesscontrol from "./cosmos/accesscontrol/index";
 import * as cosmos_accesscontrol_x from "./cosmos/accesscontrol_x/index";
@@ -53,6 +54,7 @@ export * from "./amino";
 export * from "./registry";
 
 export const Encoder = {
+	confidentialtransfers: confidentialtransfers,
 	confio: confio,
 	cosmos: {
 		accesscontrol: cosmos_accesscontrol,
@@ -64,10 +66,7 @@ export const Encoder = {
 			abci: { v1beta1: cosmos_base_abci_v1beta1 },
 			kv: { v1beta1: cosmos_base_kv_v1beta1 },
 			query: { v1beta1: cosmos_base_query_v1beta1 },
-			reflection: {
-				v1beta1: cosmos_base_reflection_v1beta1,
-				v2alpha1: cosmos_base_reflection_v2alpha1
-			},
+			reflection: { v1beta1: cosmos_base_reflection_v1beta1, v2alpha1: cosmos_base_reflection_v2alpha1 },
 			snapshots: { v1beta1: cosmos_base_snapshots_v1beta1 },
 			store: { v1beta1: cosmos_base_store_v1beta1 },
 			tendermint: { v1beta1: cosmos_base_tendermint_v1beta1 },
@@ -91,10 +90,7 @@ export const Encoder = {
 		params: { types: cosmos_params_types, v1beta1: cosmos_params_v1beta1 },
 		slashing: { v1beta1: cosmos_slashing_v1beta1 },
 		staking: { v1beta1: cosmos_staking_v1beta1 },
-		tx: {
-			signing: { v1beta1: cosmos_tx_signing_v1beta1 },
-			v1beta1: cosmos_tx_v1beta1
-		},
+		tx: { signing: { v1beta1: cosmos_tx_signing_v1beta1 }, v1beta1: cosmos_tx_v1beta1 },
 		upgrade: { v1beta1: cosmos_upgrade_v1beta1 },
 		vesting: { v1beta1: cosmos_vesting_v1beta1 }
 	},

--- a/packages/cosmos/library/encoding/registry.ts
+++ b/packages/cosmos/library/encoding/registry.ts
@@ -1,3 +1,9 @@
+import { registry as confidentialtransfers_confidential_registry } from "./confidentialtransfers/confidential";
+import { registry as confidentialtransfers_cryptography_registry } from "./confidentialtransfers/cryptography";
+import { registry as confidentialtransfers_genesis_registry } from "./confidentialtransfers/genesis";
+import { registry as confidentialtransfers_params_registry } from "./confidentialtransfers/params";
+import { registry as confidentialtransfers_tx_registry } from "./confidentialtransfers/tx";
+import { registry as confidentialtransfers_zk_registry } from "./confidentialtransfers/zk";
 import { registry as confio_proofs_registry } from "./confio/proofs";
 import { registry as cosmos_accesscontrol_accesscontrol_registry } from "./cosmos/accesscontrol/accesscontrol";
 import { registry as cosmos_accesscontrol_x_genesis_registry } from "./cosmos/accesscontrol_x/genesis";
@@ -111,6 +117,12 @@ import { registry as tokenfactory_params_registry } from "./tokenfactory/params"
 import { registry as tokenfactory_tx_registry } from "./tokenfactory/tx";
 
 export const seiProtoRegistry = [
+	...confidentialtransfers_confidential_registry,
+	...confidentialtransfers_cryptography_registry,
+	...confidentialtransfers_genesis_registry,
+	...confidentialtransfers_params_registry,
+	...confidentialtransfers_tx_registry,
+	...confidentialtransfers_zk_registry,
 	...confio_proofs_registry,
 	...cosmos_accesscontrol_x_genesis_registry,
 	...cosmos_accesscontrol_x_query_registry,

--- a/packages/cosmos/library/rest/confidentialtransfers/query.ts
+++ b/packages/cosmos/library/rest/confidentialtransfers/query.ts
@@ -1,0 +1,18 @@
+import * as fm from "../fetch";
+
+import type { GetAllCtAccountsRequest, GetAllCtAccountsResponse, GetCtAccountRequest, GetCtAccountResponse } from "../../types/confidentialtransfers/query.ts";
+
+export class Query {
+	static GetCtAccount(req: GetCtAccountRequest, initReq?: fm.InitReq): Promise<GetCtAccountResponse> {
+		return fm.fetchReq<GetCtAccountRequest, GetCtAccountResponse>(
+			`/seichain/confidentialtransfers/account/${req["address"]}/denom/${req["denom"]}?${fm.renderURLSearchParams(req, ["address", "denom"])}`,
+			{ ...initReq, method: "GET" }
+		);
+	}
+	static GetAllCtAccounts(req: GetAllCtAccountsRequest, initReq?: fm.InitReq): Promise<GetAllCtAccountsResponse> {
+		return fm.fetchReq<GetAllCtAccountsRequest, GetAllCtAccountsResponse>(
+			`/seichain/confidentialtransfers/accounts/${req["address"]}?${fm.renderURLSearchParams(req, ["address"])}`,
+			{ ...initReq, method: "GET" }
+		);
+	}
+}

--- a/packages/cosmos/library/rest/index.ts
+++ b/packages/cosmos/library/rest/index.ts
@@ -1,3 +1,4 @@
+import { Query as confidentialtransfers } from "./confidentialtransfers/query";
 import { Query as cosmos_accesscontrol_x } from "./cosmos/accesscontrol_x/query";
 import { Query as cosmos_auth_v1beta1 } from "./cosmos/auth/v1beta1/query";
 import { Query as cosmos_authz_v1beta1 } from "./cosmos/authz/v1beta1/query";
@@ -18,6 +19,7 @@ import { Query as oracle } from "./oracle/query";
 import { Query as tokenfactory } from "./tokenfactory/query";
 
 export const Querier = {
+	confidentialtransfers: confidentialtransfers,
 	cosmos: {
 		accesscontrol_x: cosmos_accesscontrol_x,
 		auth: { v1beta1: cosmos_auth_v1beta1 },

--- a/packages/cosmos/library/types/confidentialtransfers/confidential.ts
+++ b/packages/cosmos/library/types/confidentialtransfers/confidential.ts
@@ -1,0 +1,20 @@
+import type { Ciphertext } from "./cryptography";
+
+export interface CtAccount {
+	/** serialized public key */
+	public_key: Uint8Array;
+	/** lo bits of the pending balance */
+	pending_balance_lo?: Ciphertext;
+	/** hi bits of the pending balance */
+	pending_balance_hi?: Ciphertext;
+	pending_balance_credit_counter: number;
+	/** elgamal encoded balance */
+	available_balance?: Ciphertext;
+	/** aes encoded balance */
+	decryptable_available_balance: string;
+}
+
+export interface CtAccountWithDenom {
+	denom: string;
+	account?: CtAccount;
+}

--- a/packages/cosmos/library/types/confidentialtransfers/cryptography.ts
+++ b/packages/cosmos/library/types/confidentialtransfers/cryptography.ts
@@ -1,0 +1,6 @@
+export interface Ciphertext {
+	/** Pedersen commitment bytes. */
+	c: Uint8Array;
+	/** Decryption handle bytes. */
+	d: Uint8Array;
+}

--- a/packages/cosmos/library/types/confidentialtransfers/genesis.ts
+++ b/packages/cosmos/library/types/confidentialtransfers/genesis.ts
@@ -1,0 +1,17 @@
+import type { CtAccount } from "./confidential";
+
+import type { Params } from "./params";
+
+export interface GenesisState {
+	/** params defines the parameters of the module. */
+	params?: Params;
+	/** accounts is an array of confidential transfer accounts */
+	accounts: GenesisCtAccount[];
+}
+
+export interface GenesisCtAccount {
+	/** account key */
+	key: Uint8Array;
+	/** confidential transfer account */
+	account?: CtAccount;
+}

--- a/packages/cosmos/library/types/confidentialtransfers/index.ts
+++ b/packages/cosmos/library/types/confidentialtransfers/index.ts
@@ -1,0 +1,9 @@
+// @ts-nocheck
+
+export * from "./confidential";
+export * from "./cryptography";
+export * from "./genesis";
+export * from "./params";
+export * from "./query";
+export * from "./tx";
+export * from "./zk";

--- a/packages/cosmos/library/types/confidentialtransfers/params.ts
+++ b/packages/cosmos/library/types/confidentialtransfers/params.ts
@@ -1,0 +1,7 @@
+export interface Params {
+	enable_ct_module: boolean;
+	range_proof_gas_cost: number;
+	enabled_denoms: string[];
+	ciphertext_gas_cost: number;
+	proof_verification_gas_cost: number;
+}

--- a/packages/cosmos/library/types/confidentialtransfers/query.ts
+++ b/packages/cosmos/library/types/confidentialtransfers/query.ts
@@ -1,0 +1,83 @@
+import type { PageRequest, PageResponse } from "../cosmos/base/query/v1beta1/pagination";
+
+import type { CtAccount, CtAccountWithDenom } from "./confidential";
+
+import type { InitializeAccountMsgProofs, TransferMsgProofs, WithdrawMsgProofs } from "./zk";
+
+export interface GetCtAccountRequest {
+	address: string;
+	denom: string;
+}
+
+export interface GetCtAccountResponse {
+	account?: CtAccount;
+}
+
+export interface GetAllCtAccountsRequest {
+	address: string;
+	/** pagination defines an optional pagination for the request. */
+	pagination?: PageRequest;
+}
+
+export interface GetAllCtAccountsResponse {
+	accounts: CtAccountWithDenom[];
+	/** pagination defines the pagination in the response. */
+	pagination?: PageResponse;
+}
+
+export interface DecryptedCtAccount {
+	/** serialized public key */
+	public_key: Uint8Array;
+	/** We use uint64 so JSON print output is consistent with pending_balance_hi */
+	pending_balance_lo: number;
+	/** hi bits of the pending balance */
+	pending_balance_hi: number;
+	/** combined pending balance */
+	combined_pending_balance: string;
+	pending_balance_credit_counter: number;
+	/** decrypted available balance */
+	available_balance: string;
+	/** decrypted aes encrypted available balance */
+	decryptable_available_balance: string;
+}
+
+export interface ApplyPendingBalanceDecrypted {
+	address: string;
+	denom: string;
+	new_decryptable_available_balance: string;
+	current_pending_balance_counter: number;
+	current_available_balance: string;
+}
+
+export interface InitializeAccountDecrypted {
+	from_address: string;
+	denom: string;
+	pubkey: Uint8Array;
+	pending_balance_lo: number;
+	pending_balance_hi: number;
+	available_balance: string;
+	decryptable_balance: string;
+	proofs?: InitializeAccountMsgProofs;
+}
+
+export interface WithdrawDecrypted {
+	from_address: string;
+	denom: string;
+	amount: string;
+	decryptable_balance: string;
+	remaining_balance_commitment: string;
+	proofs?: WithdrawMsgProofs;
+}
+
+export interface TransferDecrypted {
+	from_address: string;
+	to_address: string;
+	denom: string;
+	transfer_amount_lo: number;
+	transfer_amount_hi: number;
+	total_transfer_amount: number;
+	remaining_balance_commitment: string;
+	decryptable_balance: string;
+	proofs?: TransferMsgProofs;
+	auditors: string[];
+}

--- a/packages/cosmos/library/types/confidentialtransfers/tx.ts
+++ b/packages/cosmos/library/types/confidentialtransfers/tx.ts
@@ -1,0 +1,86 @@
+import type { Ciphertext } from "./cryptography";
+
+import type {
+	CiphertextCiphertextEqualityProof,
+	CiphertextValidityProof,
+	CloseAccountMsgProofs,
+	InitializeAccountMsgProofs,
+	TransferMsgProofs,
+	WithdrawMsgProofs
+} from "./zk";
+
+export interface MsgTransfer {
+	from_address: string;
+	to_address: string;
+	denom: string;
+	from_amount_lo?: Ciphertext;
+	from_amount_hi?: Ciphertext;
+	to_amount_lo?: Ciphertext;
+	to_amount_hi?: Ciphertext;
+	remaining_balance?: Ciphertext;
+	decryptable_balance: string;
+	proofs?: TransferMsgProofs;
+	auditors: Auditor[];
+}
+
+export type MsgTransferResponse = {};
+
+export interface Auditor {
+	auditor_address: string;
+	encrypted_transfer_amount_lo?: Ciphertext;
+	encrypted_transfer_amount_hi?: Ciphertext;
+	transfer_amount_lo_validity_proof?: CiphertextValidityProof;
+	transfer_amount_hi_validity_proof?: CiphertextValidityProof;
+	transfer_amount_lo_equality_proof?: CiphertextCiphertextEqualityProof;
+	transfer_amount_hi_equality_proof?: CiphertextCiphertextEqualityProof;
+}
+
+export interface MsgInitializeAccount {
+	from_address: string;
+	denom: string;
+	public_key: Uint8Array;
+	decryptable_balance: string;
+	pending_balance_lo?: Ciphertext;
+	pending_balance_hi?: Ciphertext;
+	available_balance?: Ciphertext;
+	proofs?: InitializeAccountMsgProofs;
+}
+
+export type MsgInitializeAccountResponse = {};
+
+export interface MsgDeposit {
+	from_address: string;
+	denom: string;
+	amount: number;
+}
+
+export type MsgDepositResponse = {};
+
+export interface MsgWithdraw {
+	from_address: string;
+	denom: string;
+	amount: string;
+	decryptable_balance: string;
+	remaining_balance_commitment?: Ciphertext;
+	proofs?: WithdrawMsgProofs;
+}
+
+export type MsgWithdrawResponse = {};
+
+export interface MsgApplyPendingBalance {
+	address: string;
+	denom: string;
+	new_decryptable_available_balance: string;
+	current_pending_balance_counter: number;
+	current_available_balance?: Ciphertext;
+}
+
+export type MsgApplyPendingBalanceResponse = {};
+
+export interface MsgCloseAccount {
+	address: string;
+	denom: string;
+	proofs?: CloseAccountMsgProofs;
+}
+
+export type MsgCloseAccountResponse = {};

--- a/packages/cosmos/library/types/confidentialtransfers/zk.ts
+++ b/packages/cosmos/library/types/confidentialtransfers/zk.ts
@@ -1,0 +1,78 @@
+export interface TransferMsgProofs {
+	remaining_balance_commitment_validity_proof?: CiphertextValidityProof;
+	sender_transfer_amount_lo_validity_proof?: CiphertextValidityProof;
+	sender_transfer_amount_hi_validity_proof?: CiphertextValidityProof;
+	recipient_transfer_amount_lo_validity_proof?: CiphertextValidityProof;
+	recipient_transfer_amount_hi_validity_proof?: CiphertextValidityProof;
+	remaining_balance_range_proof?: RangeProof;
+	remaining_balance_equality_proof?: CiphertextCommitmentEqualityProof;
+	transfer_amount_lo_equality_proof?: CiphertextCiphertextEqualityProof;
+	transfer_amount_hi_equality_proof?: CiphertextCiphertextEqualityProof;
+	transfer_amount_lo_range_proof?: RangeProof;
+	transfer_amount_hi_range_proof?: RangeProof;
+}
+
+export interface InitializeAccountMsgProofs {
+	pubkey_validity_proof?: PubkeyValidityProof;
+	zero_pending_balance_lo_proof?: ZeroBalanceProof;
+	zero_pending_balance_hi_proof?: ZeroBalanceProof;
+	zero_available_balance_proof?: ZeroBalanceProof;
+}
+
+export interface WithdrawMsgProofs {
+	remaining_balance_range_proof?: RangeProof;
+	remaining_balance_equality_proof?: CiphertextCommitmentEqualityProof;
+}
+
+export interface CloseAccountMsgProofs {
+	zero_available_balance_proof?: ZeroBalanceProof;
+	zero_pending_balance_lo_proof?: ZeroBalanceProof;
+	zero_pending_balance_hi_proof?: ZeroBalanceProof;
+}
+
+export interface PubkeyValidityProof {
+	y: Uint8Array;
+	z: Uint8Array;
+}
+
+export interface CiphertextValidityProof {
+	/** First commitment */
+	commitment_1: Uint8Array;
+	/** Second commitment */
+	commitment_2: Uint8Array;
+	/** First response */
+	response_1: Uint8Array;
+	/** Second response */
+	response_2: Uint8Array;
+}
+
+export interface RangeProof {
+	proof: Uint8Array;
+	randomness: Uint8Array;
+	upper_bound: number;
+}
+
+export interface CiphertextCommitmentEqualityProof {
+	y0: Uint8Array;
+	y1: Uint8Array;
+	y2: Uint8Array;
+	zs: Uint8Array;
+	zx: Uint8Array;
+	zr: Uint8Array;
+}
+
+export interface CiphertextCiphertextEqualityProof {
+	y0: Uint8Array;
+	y1: Uint8Array;
+	y2: Uint8Array;
+	y3: Uint8Array;
+	zs: Uint8Array;
+	zx: Uint8Array;
+	zr: Uint8Array;
+}
+
+export interface ZeroBalanceProof {
+	y_p: Uint8Array;
+	y_d: Uint8Array;
+	z: Uint8Array;
+}


### PR DESCRIPTION
As the confidential transfers module has been [merged into main](https://github.com/sei-protocol/sei-chain/commit/573376218e4e69da43ce29be7021a620cbf3e896) this PR enables the proto encoding/decoding, rest client, and typescript types for the new Confidential Transfers module.