### PR TITLE
replaced cosmology links with hyperweb links

### DIFF
--- a/packages/create-sei/README.md
+++ b/packages/create-sei/README.md
@@ -28,7 +28,7 @@ Cosmos based Sei Applications interact with the CosmWasm VM on the chain. Use th
 If you think your app might require interaction with native Cosmos modules, you should check the list of [precompiles](https://www.docs.sei.io/dev-interoperability/precompiles/addr) to determine if the same support can be offered by the EVM.
 
 Cosmos Applications use
-- [CosmosKit](https://cosmology.zone/products/cosmos-kit)
+- [CosmosKit](https://hyperweb.io/stack/cosmos-kit)
 - [@sei-js/cosmjs](https://sei-protocol.github.io/sei-js/modules/cosmjs.html)
 - [Cosmjs](https://github.com/cosmos/cosmjs)
 

--- a/packages/create-sei/templates/next-cosmos-template/src/app/components/Homepage/Homepage.tsx
+++ b/packages/create-sei/templates/next-cosmos-template/src/app/components/Homepage/Homepage.tsx
@@ -33,7 +33,7 @@ const helpItems: HelpItem[] = [
 	{
 		title: 'CosmosKit',
 		description: "Learn about CosmosKit and it's hooks for chain interaction.",
-		link: 'https://docs.cosmology.zone/cosmos-kit/get-started'
+		link: 'https://hyperweb.io/stack/cosmos-kit'
 	},
 	{
 		title: 'sei-js',

--- a/packages/create-sei/templates/vite-cosmos-template/src/components/Homepage/Homepage.tsx
+++ b/packages/create-sei/templates/vite-cosmos-template/src/components/Homepage/Homepage.tsx
@@ -31,7 +31,7 @@ const helpItems: HelpItem[] = [
 	{
 		title: 'CosmosKit',
 		description: "Learn about CosmosKit and it's hooks for chain interaction.",
-		link: 'https://docs.cosmology.zone/cosmos-kit/get-started'
+		link: 'https://hyperweb.io/stack/cosmos-kit'
 	},
 	{
 		title: 'sei-js',


### PR DESCRIPTION
Hello, I’m Eason, a software engineer with the hyperweb.io team (formerly known as cosmology.zone).
We’ve recently updated our brand and domain to hyperweb.io.
This PR updates the outdated references from cosmology.zone to hyperweb.io in the sei-js codebase to reflect the change.
I’d appreciate it if you could take a moment to review the changes. Thank you!
@pyramation 