### PR TITLE
Deprecate Cosmos and Cosmjs packages

### DIFF
--- a/.changeset/every-turtles-grab.md
+++ b/.changeset/every-turtles-grab.md
@@ -1,0 +1,6 @@
+---
+"@sei-js/cosmjs": patch
+"@sei-js/cosmos": patch
+---
+
+Deprecating these packages

--- a/packages/cosmjs/README.md
+++ b/packages/cosmjs/README.md
@@ -1,3 +1,5 @@
+> **⚠️ DEPRECATION NOTICE**: According to [SIP-3](https://github.com/sei-protocol/sei-improvement-proposals/blob/main/SIPS/sip-3.md), Cosmos functionality has been deprecated in favor of EVM. This package (`@sei-js/cosmjs`) will be deprecated in future releases. Please migrate to EVM-based solutions using `@sei-js/evm` or `@sei-js/precompiles`.
+
 # @sei-js/cosmjs
 
 The `@sei-js/cosmjs` package contains helper functions for wallet connection, transaction signing, RPC querying, and more for those using cosmjs. 

--- a/packages/cosmjs/README.md
+++ b/packages/cosmjs/README.md
@@ -1,4 +1,4 @@
-> **⚠️ DEPRECATION NOTICE**: According to [SIP-3](https://github.com/sei-protocol/sei-improvement-proposals/blob/main/SIPS/sip-3.md), Cosmos functionality has been deprecated in favor of EVM. This package (`@sei-js/cosmjs`) will be deprecated in future releases. Please migrate to EVM-based solutions using `@sei-js/evm` or `@sei-js/precompiles`.
+> **⚠️ DEPRECATION NOTICE**: According to [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md), Cosmos functionality has been deprecated in favor of EVM. This package (`@sei-js/cosmjs`) will be deprecated in future releases.
 
 # @sei-js/cosmjs
 

--- a/packages/cosmos/README.md
+++ b/packages/cosmos/README.md
@@ -1,6 +1,6 @@
 # @sei-js/cosmos
 
-> **⚠️ DEPRECATION NOTICE**: According to [SIP-3](https://github.com/sei-protocol/sei-improvement-proposals/blob/main/SIPS/sip-3.md), Cosmos functionality has been deprecated in favor of EVM. This package (`@sei-js/cosmos`) will be deprecated in future releases. Please migrate to EVM-based solutions using `@sei-js/evm` or `@sei-js/precompiles`.
+> **⚠️ DEPRECATION NOTICE**: According to [SIP-3](https://github.com/sei-protocol/sips/blob/main/sips/sip-3.md), Cosmos functionality has been deprecated in favor of EVM. This package (`@sei-js/cosmos`) will be deprecated in future releases.
 
 `@sei-js/cosmos` is a set of TypeScript libraries for interaction with Sei, using Cosmos standards and interfaces. It provides:
 

--- a/packages/cosmos/README.md
+++ b/packages/cosmos/README.md
@@ -1,5 +1,7 @@
 # @sei-js/cosmos
 
+> **⚠️ DEPRECATION NOTICE**: According to [SIP-3](https://github.com/sei-protocol/sei-improvement-proposals/blob/main/SIPS/sip-3.md), Cosmos functionality has been deprecated in favor of EVM. This package (`@sei-js/cosmos`) will be deprecated in future releases. Please migrate to EVM-based solutions using `@sei-js/evm` or `@sei-js/precompiles`.
+
 `@sei-js/cosmos` is a set of TypeScript libraries for interaction with Sei, using Cosmos standards and interfaces. It provides:
 
 > **For EVM Developers**: @sei-js/cosmos/types provides TypeScript types for all custom Sei modules, simplifying integration between Cosmos and EVM ecosystems.


### PR DESCRIPTION
This PR adds a note to the README so that we can deprecate in NPM in accordance with SIP-3