### PR TITLE
Update release workflow and package repositories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release
@@ -21,6 +26,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -42,5 +48,3 @@ jobs:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}

--- a/packages/create-sei/package.json
+++ b/packages/create-sei/package.json
@@ -1,6 +1,11 @@
 {
 	"name": "@sei-js/create-sei",
 	"version": "1.0.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sei-protocol/sei-js.git",
+		"directory": "packages/create-sei"
+	},
 	"module": "dist/main.js",
 	"type": "module",
 	"bin": "./dist/main.js",

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -16,7 +16,11 @@
 	},
 	"homepage": "https://github.com/sei-protocol/sei-js#readme",
 	"keywords": ["sei", "javascript", "typescript", "ledger"],
-	"repository": "git@github.com:sei-protocol/sei-js.git",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sei-protocol/sei-js.git",
+		"directory": "packages/ledger"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"access": "public"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -6,12 +6,7 @@
 	"bin": "./bin/mcp-server.js",
 	"main": "./dist/esm/index.js",
 	"module": "./dist/esm/index.js",
-	"files": [
-		"dist/",
-		"bin/",
-		"README.md",
-		"LICENSE"
-	],
+	"files": ["dist/", "bin/", "README.md", "LICENSE"],
 	"scripts": {
 		"build": "rm -rf dist && tsc",
 		"start": "node dist/esm/index.js",
@@ -40,18 +35,8 @@
 		"viem": "^2.30.5",
 		"zod": "^3.24.2"
 	},
-	"keywords": [
-		"mcp",
-		"model-context-protocol",
-		"evm",
-		"blockchain",
-		"sei",
-		"web3",
-		"smart-contracts",
-		"ai",
-		"agent"
-	],
-	"author": "Etheral <etheral.eth.dev@gmail.com>",
+	"keywords": ["mcp", "model-context-protocol", "evm", "blockchain", "sei", "web3", "smart-contracts", "ai", "agent"],
+	"author": "@codebycarson",
 	"license": "MIT",
 	"engines": {
 		"node": ">=18.0.0"
@@ -62,9 +47,9 @@
 		"directory": "packages/mcp-server"
 	},
 	"bugs": {
-		"url": "https://github.com/sei-protocol/sei-mcp-server/issues"
+		"url": "https://github.com/sei-protocol/sei-js/issues"
 	},
-	"homepage": "https://github.com/sei-protocol/sei-mcp-server#readme",
+	"homepage": "https://github.com/sei-protocol/sei-js/tree/main/packages/mcp-server#readme",
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -58,7 +58,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sei-protocol/sei-mcp-server"
+		"url": "https://github.com/sei-protocol/sei-js.git",
+		"directory": "packages/mcp-server"
 	},
 	"bugs": {
 		"url": "https://github.com/sei-protocol/sei-mcp-server/issues"

--- a/packages/precompiles/package.json
+++ b/packages/precompiles/package.json
@@ -15,7 +15,11 @@
 	},
 	"homepage": "https://github.com/sei-protocol/sei-js#readme",
 	"keywords": ["sei", "javascript", "typescript", "node", "evm"],
-	"repository": "git@github.com:sei-protocol/sei-js.git",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sei-protocol/sei-js.git",
+		"directory": "packages/precompiles"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"access": "public"

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -24,7 +24,11 @@
 		"typescript",
 		"registry"
 	],
-	"repository": "git@github.com:sei-protocol/sei-js.git",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sei-protocol/sei-js.git",
+		"directory": "packages/registry"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"access": "public"

--- a/packages/sei-global-wallet/package.json
+++ b/packages/sei-global-wallet/package.json
@@ -2,6 +2,11 @@
 	"name": "@sei-js/sei-global-wallet",
 	"description": "Sei Global Wallet is a library to support Dynamic Global Wallets",
 	"version": "1.3.5",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sei-protocol/sei-js.git",
+		"directory": "packages/sei-global-wallet"
+	},
 	"type": "module",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
This pull request primarily updates the repository metadata in several `package.json` files to use the correct multi-package (monorepo) format and makes minor improvements to the release workflow. The changes ensure each package correctly references its location in the monorepo and improve release automation compatibility with npm.

Repository metadata standardization:

* Updated the `repository` field in the `package.json` files for `@sei-js/create-sei`, `@sei-js/ledger`, `@sei-js/precompiles`, `@sei-js/registry`, and `@sei-js/sei-global-wallet` to use the object format with the correct `directory` property, ensuring accurate links and improved compatibility with npm and GitHub. [[1]](diffhunk://#diff-fe89d2d2006e92a6d9bb095fa4737e8d143f3b0c760b98d79d3f7d093590af41R4-R8) [[2]](diffhunk://#diff-4ddbf29a24a2ebef9c571f705a192ca503aff1e9f3e3b832e21499ab023667d5L19-R23) [[3]](diffhunk://#diff-8a5fdc3614d4e0d7c2b273298c1d54dfa91ff056e14bd86c8708763b0efaad0aL18-R22) [[4]](diffhunk://#diff-becf31d369bc715246d335c9be51c4b72308ea0241c063fee70752b4caa704b1L27-R31) [[5]](diffhunk://#diff-52b55cb2818414566ce511860ab3a25467781f98397ed3e6fdec00b57ebbc3ddR5-R9)
* Fixed the `repository` field in `packages/mcp-server/package.json` to point to the correct monorepo URL and directory.

Release workflow improvements:

* Added explicit `permissions` for `id-token`, `contents`, and `pull-requests` in `.github/workflows/release.yml` to support secure publishing and automation.
* Configured `actions/setup-node` with the `registry-url` for npm publishing in the release workflow.
* Removed unused environment variables (`NPM_TOKEN`, `NX_CLOUD_ACCESS_TOKEN`) from the release workflow, likely due to improved authentication methods.Add OIDC permissions and npm registry config to the release workflow, and remove direct NPM_TOKEN/NX_CLOUD_ACCESS_TOKEN env usage. Standardize package.json repository metadata across multiple packages to point to the monorepo (https://github.com/sei-protocol/sei-js.git) with package-specific directory fields.

Files changed: .github/workflows/release.yml, packages/create-sei/package.json, packages/ledger/package.json, packages/mcp-server/package.json, packages/precompiles/package.json, packages/registry/package.json, packages/sei-global-wallet/package.json.

These changes enable tokenless (id-token) publishing flows and make package repo metadata accurate for each package in the monorepo.