### PR TITLE
Pin Node.js 24 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,11 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Setup Node.js
+
+      - name: Setup Node.js (for npm OIDC publishing)
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm


### PR DESCRIPTION
This pull request makes a minor update to the Node.js setup step in the release workflow. The change specifies Node.js version 24 directly instead of using the `.nvmrc` file, and clarifies the step's purpose for npm OIDC publishing.Replace node-version-file: '.nvmrc' with an explicit node-version: '24' in the release GitHub Actions workflow and rename the step to 'Setup Node.js (for npm OIDC publishing)'. This ensures the workflow uses Node 24 for npm OIDC publishing rather than relying on the repo's .nvmrc.

Example comes from here: https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow