### PR TITLE
fix(registry): remove install-breaking postinstall hook

### DIFF
--- a/.changeset/clean-spiders-smile.md
+++ b/.changeset/clean-spiders-smile.md
@@ -1,0 +1,5 @@
+---
+"@sei-js/registry": patch
+---
+
+Stop running Git submodule commands when consumers install the registry package.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch the full history instead of a shallow clone
+          submodules: recursive
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch the full history instead of a shallow clone
+          submodules: recursive
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -84,10 +84,10 @@ defect.
   startup is the intent. Do not ask for a thrown error the caller might swallow.
 - **`packages/registry/chain-registry` and `.../community-assetlist` are
   missing from the tree.** Both are git submodules (`.gitmodules`) and are
-  listed in `.gitignore`. Only `release.yml` checks them out with
-  `submodules: recursive`; the PR gate in `checks.yml` does a plain checkout
-  and relies on the `registry` package's `postinstall`. Their JSON is vendored
-  upstream — review the TypeScript wrappers, not the data.
+  listed in `.gitignore`. Workflows that build the registry check them out with
+  `submodules: recursive`; local source builds must initialize them explicitly.
+  Their JSON is vendored upstream — review the TypeScript wrappers, not the
+  data.
 - **Biome findings are not enforced anywhere.** `biome.json` configures tabs,
   160-column lines, single quotes and no trailing commas, but no package
   defines a `biome` script and `.github/workflows/checks.yml` runs only

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -14,8 +14,7 @@
 		"build:cjs": "tsc --outDir dist/cjs --module commonjs",
 		"build:esm": "tsc --outDir dist/esm --module esnext",
 		"build:types": "tsc --project ./tsconfig.declaration.json",
-		"test": "jest",
-		"postinstall": "git submodule update --init --recursive"
+		"test": "jest"
 	},
 	"homepage": "https://github.com/sei-protocol/sei-js#readme",
 	"keywords": [


### PR DESCRIPTION
## Summary
- remove the published Git submodule `postinstall` hook so consumers can install outside a Git checkout
- initialize registry submodules explicitly in build and coverage CI
- add a patch changeset and update repository guidance

Linear: [PLT-842](https://linear.app/seilabs/issue/PLT-842/sei-jsregistry-remove-install-breaking-postinstall-git-submodule)

## Test plan
- [x] Build `@sei-js/registry`
- [x] Run all 14 registry tests
- [x] Pack, install, and import the package with Git discovery disabled
- [x] Validate changeset status and workspace diagnostics

Made with [Cursor](https://cursor.com)