### PR TITLE
fix(precompiles): export solo precompile from ethers entrypoint

### DIFF
--- a/.changeset/export-solo-precompile-ethers.md
+++ b/.changeset/export-solo-precompile-ethers.md
@@ -2,4 +2,6 @@
 '@sei-js/precompiles': minor
 ---
 
-Export the Solo precompile from the `ethers` entrypoint. `ETHERS_SOLO_PRECOMPILE_ABI` and `getSoloPrecompileEthersV6Contract` were implemented but never re-exported from `src/ethers/index.ts`, so they were unreachable from both `@sei-js/precompiles` and `@sei-js/precompiles/ethers`.
+Export the Solo precompile from the `ethers` entrypoint. `ETHERS_SOLO_PRECOMPILE_ABI` and `getSoloPrecompileEthersV6Contract` were implemented but never re-exported from `src/ethers/index.ts`, so they were unreachable from the `@sei-js/precompiles` package root.
+
+The `@sei-js/precompiles/ethers` subpath shown in the doc examples remains unresolvable and is unchanged here — the package still publishes no `exports` map. That is tracked separately.

--- a/.changeset/export-solo-precompile-ethers.md
+++ b/.changeset/export-solo-precompile-ethers.md
@@ -1,0 +1,5 @@
+---
+'@sei-js/precompiles': minor
+---
+
+Export the Solo precompile from the `ethers` entrypoint. `ETHERS_SOLO_PRECOMPILE_ABI` and `getSoloPrecompileEthersV6Contract` were implemented but never re-exported from `src/ethers/index.ts`, so they were unreachable from both `@sei-js/precompiles` and `@sei-js/precompiles/ethers`.

--- a/packages/precompiles/src/__tests__/barrelParity.spec.ts
+++ b/packages/precompiles/src/__tests__/barrelParity.spec.ts
@@ -1,0 +1,38 @@
+import * as ethersBarrel from '../ethers';
+import * as precompilesBarrel from '../precompiles';
+import * as viemBarrel from '../viem';
+
+const precompileNamesFrom = (barrel: Record<string, unknown>, prefix: '' | 'ETHERS_' | 'VIEM_'): string[] => {
+	const pattern = new RegExp(`^${prefix}([A-Z0-9]+)_PRECOMPILE_ABI$`);
+
+	return Object.keys(barrel)
+		.map((key) => pattern.exec(key)?.[1])
+		.filter((name): name is string => name !== undefined)
+		.sort();
+};
+
+describe('Precompile barrel parity', () => {
+	const precompileNames = precompileNamesFrom(precompilesBarrel, '');
+	const ethersNames = precompileNamesFrom(ethersBarrel, 'ETHERS_');
+	const viemNames = precompileNamesFrom(viemBarrel, 'VIEM_');
+
+	// Without this the three comparisons below would pass on three empty sets if the
+	// ABI naming convention ever changes out from under the pattern above.
+	it('discovers precompiles in the base barrel', () => {
+		expect(precompileNames.length).toBeGreaterThan(0);
+	});
+
+	it('exposes the same precompiles from the ethers barrel as the base barrel', () => {
+		expect(ethersNames).toEqual(precompileNames);
+	});
+
+	it('exposes the same precompiles from the viem barrel as the base barrel', () => {
+		expect(viemNames).toEqual(precompileNames);
+	});
+
+	it('exposes one ethers contract factory per precompile', () => {
+		const factories = Object.keys(ethersBarrel).filter((key) => /^get[A-Za-z]+PrecompileEthersV6Contract$/.test(key));
+
+		expect(factories).toHaveLength(precompileNames.length);
+	});
+});

--- a/packages/precompiles/src/__tests__/barrelParity.spec.ts
+++ b/packages/precompiles/src/__tests__/barrelParity.spec.ts
@@ -30,9 +30,12 @@ describe('Precompile barrel parity', () => {
 		expect(viemNames).toEqual(precompileNames);
 	});
 
-	it('exposes one ethers contract factory per precompile', () => {
-		const factories = Object.keys(ethersBarrel).filter((key) => /^get[A-Za-z]+PrecompileEthersV6Contract$/.test(key));
+	it('exposes an ethers contract factory for each precompile', () => {
+		const factories = Object.keys(ethersBarrel)
+			.map((key) => /^get([A-Za-z]+)PrecompileEthersV6Contract$/.exec(key)?.[1]?.toUpperCase())
+			.filter((name): name is string => name !== undefined)
+			.sort();
 
-		expect(factories).toHaveLength(precompileNames.length);
+		expect(factories).toEqual(precompileNames);
 	});
 });

--- a/packages/precompiles/src/__tests__/barrelParity.spec.ts
+++ b/packages/precompiles/src/__tests__/barrelParity.spec.ts
@@ -32,7 +32,7 @@ describe('Precompile barrel parity', () => {
 
 	it('exposes an ethers contract factory for each precompile', () => {
 		const factories = Object.keys(ethersBarrel)
-			.map((key) => /^get([A-Za-z]+)PrecompileEthersV6Contract$/.exec(key)?.[1]?.toUpperCase())
+			.map((key) => /^get([A-Za-z0-9]+)PrecompileEthersV6Contract$/.exec(key)?.[1]?.toUpperCase())
 			.filter((name): name is string => name !== undefined)
 			.sort();
 

--- a/packages/precompiles/src/ethers/__tests__/ethersPrecompiles.spec.ts
+++ b/packages/precompiles/src/ethers/__tests__/ethersPrecompiles.spec.ts
@@ -10,6 +10,7 @@ import {
 	ETHERS_ORACLE_PRECOMPILE_ABI,
 	ETHERS_POINTERVIEW_PRECOMPILE_ABI,
 	ETHERS_POINTER_PRECOMPILE_ABI,
+	ETHERS_SOLO_PRECOMPILE_ABI,
 	ETHERS_STAKING_PRECOMPILE_ABI,
 	ETHERS_WASM_PRECOMPILE_ABI,
 	getAddressPrecompileEthersV6Contract,
@@ -21,6 +22,7 @@ import {
 	getOraclePrecompileEthersV6Contract,
 	getPointerPrecompileEthersV6Contract,
 	getPointerviewPrecompileEthersV6Contract,
+	getSoloPrecompileEthersV6Contract,
 	getStakingPrecompileEthersV6Contract,
 	getWasmPrecompileEthersV6Contract
 } from '../';
@@ -51,7 +53,6 @@ import {
 	WASM_PRECOMPILE_ABI,
 	WASM_PRECOMPILE_ADDRESS
 } from '../../precompiles';
-import { ETHERS_SOLO_PRECOMPILE_ABI, getSoloPrecompileEthersV6Contract } from '../soloPrecompile';
 
 const FACTORIES: [string, string, InterfaceAbi, unknown, (runner: ContractRunner) => Contract][] = [
 	['ADDRESS', ADDRESS_PRECOMPILE_ADDRESS, ADDRESS_PRECOMPILE_ABI, ETHERS_ADDRESS_PRECOMPILE_ABI, getAddressPrecompileEthersV6Contract],

--- a/packages/precompiles/src/ethers/index.ts
+++ b/packages/precompiles/src/ethers/index.ts
@@ -7,5 +7,6 @@ export * from './jsonPrecompile';
 export * from './oraclePrecompile';
 export * from './pointerPrecompile';
 export * from './pointerviewPrecompile';
+export * from './soloPrecompile';
 export * from './stakingPrecompile';
 export * from './wasmPrecompile';

--- a/packages/precompiles/src/ethers/soloPrecompile.ts
+++ b/packages/precompiles/src/ethers/soloPrecompile.ts
@@ -26,7 +26,7 @@ export const ETHERS_SOLO_PRECOMPILE_ABI = SOLO_PRECOMPILE_ABI as InterfaceAbi;
  * ```
  *
  * @param runner A [Provider](https://docs.ethers.org/v6/api/providers/) (read-only) or ethers.Signer to use with the contract.
- * @returns The typed contract instance for interacting with the Oracle precompile contract.
+ * @returns The typed contract instance for interacting with the Solo precompile contract.
  * @category Contract Factory
  */
 export const getSoloPrecompileEthersV6Contract = (runner: ContractRunner) => {


### PR DESCRIPTION
Fixes PLT-848.

## Problem

`src/ethers/soloPrecompile.ts` implements `ETHERS_SOLO_PRECOMPILE_ABI` and `getSoloPrecompileEthersV6Contract`, but `src/ethers/index.ts` never re-exported it. Solo *is* exported from the `precompiles/` and `viem/` barrels, so the omission was ethers-only and unintentional.

This is present in published `2.1.2`, so `getSoloPrecompileEthersV6Contract` has never been reachable from the package root for ethers consumers — the file ships in `dist/*/ethers/soloPrecompile.js` but nothing re-exported it.

The existing suite masked it: `ethersPrecompiles.spec.ts` imported solo via a direct module path (`from '../soloPrecompile'`) rather than through the barrel, so it passed.

## Changes

- Add `export * from './soloPrecompile';` to `src/ethers/index.ts`.
- Point the ethers spec at the barrel so a missing export fails the suite.
- Add `src/__tests__/barrelParity.spec.ts`, asserting the `precompiles`, `ethers`, and `viem` barrels expose the same set of precompiles. This is the actual root cause and it would have recurred on the next precompile.
- Fix a copy-paste in the solo JSDoc that said "Oracle precompile contract".

The parity test derives names from each barrel's `*_PRECOMPILE_ABI` constants rather than hardcoding a count, so it stays correct as precompiles are added or removed. It also asserts the base barrel is non-empty, otherwise the three comparisons would pass vacuously on three empty sets if the naming convention ever changed.

## Verification

- Removing the new barrel line again makes `barrelParity.spec.ts` fail (2 of 4 assertions), confirming the guard actually catches this bug rather than just passing alongside the fix.
- `import { getSoloPrecompileEthersV6Contract } from '@sei-js/precompiles'` verified against a real `npm pack` tarball: resolves, and the returned contract targets `0x…100C`.
- `tsc --noEmit` clean, 41/41 jest tests pass, biome clean, full build clean.

## Note, not fixed here

`@sei-js/precompiles/ethers` — the subpath used throughout our JSDoc examples — does not resolve at all from a packed tarball (`MODULE_NOT_FOUND`). The package has no `exports` map and no `ethers/` directory at the package root. That is a separate packaging bug with wider blast radius, so it is out of scope for this PR.

Made with [Cursor](https://cursor.com)