### PR TITLE
ci: fix registry notification workflow (PLT-846)

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,4 +1,4 @@
-# runs if /packages/registry/** is updated and the release workflow completes successfully
+# Notify the registry API after the release workflow completes successfully.
 name: Update Registry Submodules
 
 on:
@@ -6,26 +6,21 @@ on:
     workflows: ["Release"]
     types:
       - completed
-  push:
-    paths:
-      - 'packages/registry/**'
+
+permissions:
+  contents: write
 
 jobs:
-  release:
+  notify:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Fetch the full history instead of a shallow clone
-
-      - name: Delay for 90 seconds to allow NPM package to propagate
+      - name: Delay for 90 seconds to allow npm package to propagate
         run: sleep 90
 
       - name: Update registry API
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: workflow_completed


### PR DESCRIPTION
## Summary
- remove the unreachable registry-path push trigger so notifications only follow successful Release workflow runs
- upgrade `peter-evans/repository-dispatch` from v1 to v4, declare its required permission, and remove the unused checkout
- complete the remaining PLT-846 CI hygiene work after #327 added PR checks, concurrency, scoped pushes, and consistent runtimes

## Test plan
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml`
- [x] YAML syntax validation
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)