### PR TITLE
docs: align README and contributor templates (PLT-839)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,34 +3,45 @@ name: Bug report
 about: Create a report to help us improve
 title: "[BUG] Issue Title"
 labels: bug, linear
-assignees: ''
+assignees: ""
 
 ---
 
-**Seid version**
-Show us output of `seid version --long | head`
+**Affected package and version**
+Select the affected package and provide its exact version:
 
-**SeiJS package & version**
-Check your `package.json` for version number and package (core/react/proto) 
+- [ ] `@sei-js/create-sei`
+- [ ] `@sei-js/mcp-server`
+- [ ] `@sei-js/precompiles`
+- [ ] `@sei-js/registry`
+- [ ] `@sei-js/sei-global-wallet`
 
-**Chain ID**
-Which chain are you running into issues with?
+Version:
+
+**Environment**
+- Runtime or browser and version:
+- Operating system:
+- Wallet or provider, if applicable:
+- Sei network and chain ID:
 
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+**To reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
+Include a minimal reproduction or code sample when possible.
+
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Logs or screenshots**
+If applicable, add logs or screenshots that help explain the problem. Remove private keys, seed phrases, and other secrets first.
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- Explain what changed and why. -->
+
+## Related issue
+
+<!-- Link the Linear issue or other relevant context. -->
+
+## Test plan
+
+<!-- List the commands and manual checks used to verify this change. -->
+
+- [ ] `bun run check`
+- [ ] `bun run build`
+- [ ] `bun run test`
+
+## Checklist
+
+- [ ] I added or updated tests where needed.
+- [ ] I added a Changeset when this affects a published package.
+- [ ] I updated documentation when behavior or usage changed.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # SeiJS
 
-SeiJS is a monorepo that contains multiple NPM libraries for writing applications that interact with Sei.
+SeiJS is a monorepo of npm packages for building EVM applications on Sei.
 
 ## Packages
 
-SeiJS consists of smaller NPM packages within the @sei-js namespace. See the package READMEs below for usage details.
+SeiJS consists of packages within the `@sei-js` namespace. See the package READMEs below for usage details.
 
-| Package                                                 | Description                                                                                                                    |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| [@sei-js/precompiles](packages/precompiles)             | Typescript library containing helper functions for interacting with Sei's precompile contracts.                                |
-| [@sei-js/create-sei](packages/create-sei)               | CLI Tool used to quickly spin up Sei Projects and dApps in either the cosmos or EVM ecosystem                                  |
-| [@sei-js/mcp-server](packages/mcp-server)               | MCP server for interacting with Sei via LLM's and agents                                                                       |
-| [@sei-js/sei-global-wallet](packages/sei-global-wallet) | A global wallet conforming to EIP-6963 allowing for AA across dApps.                                                           |
-| [@sei-js/registry](packages/registry)                   | TypeScript library for Sei chain constants and assets.                                                                         |
+| Package                                                 | Description                                                                       |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [@sei-js/precompiles](packages/precompiles)             | TypeScript ABIs, addresses, and Ethers/Viem helpers for Sei EVM precompiles.       |
+| [@sei-js/create-sei](packages/create-sei)               | CLI for scaffolding Sei EVM applications and dApps.                               |
+| [@sei-js/mcp-server](packages/mcp-server)               | MCP server that lets AI assistants and agents interact with Sei EVM.              |
+| [@sei-js/sei-global-wallet](packages/sei-global-wallet) | Global wallet integration for EIP-6963 and account abstraction across dApps.      |
+| [@sei-js/registry](packages/registry)                   | TypeScript library for Sei chain constants and assets.                            |
 
 ## Development
 


### PR DESCRIPTION
## Summary

- align the root README with the current Bun-based, EVM-first package set
- replace obsolete `seid` and removed-package prompts in the bug report template
- add a pull request template with the repository's current checks and release checklist

## Related issue

[PLT-839](https://linear.app/seilabs/issue/PLT-839/fix-readme-and-package-drift-registry-pnpm-dead-issue-template-refs)

## Test plan

- [x] `bun run check`
- [x] `git diff --check`

Changeset not required because this only updates repository documentation and contribution templates.

Made with [Cursor](https://cursor.com)