### PR TITLE
fix(mcp-server): return prompt validation errors for invalid networks

### DIFF
--- a/.changeset/fix-mcp-network-list-validation.md
+++ b/.changeset/fix-mcp-network-list-validation.md
@@ -1,0 +1,5 @@
+---
+'@sei-js/mcp-server': patch
+---
+
+Return MCP validation errors for unsupported `compare_networks` entries instead of throwing an internal error.

--- a/packages/mcp-server/src/core/prompts.ts
+++ b/packages/mcp-server/src/core/prompts.ts
@@ -5,26 +5,24 @@ import { isWalletEnabled } from './config.js';
 
 const networkListSchema = z
 	.string()
-	.superRefine((value, context) => {
+	.transform((value, context) => {
 		const networks = value.split(',').map((network) => network.trim());
 		if (networks.length === 0 || networks.some((network) => network.length === 0)) {
 			context.addIssue({ code: z.ZodIssueCode.custom, message: 'At least one supported network is required.' });
-			return;
+			return z.NEVER;
 		}
+
+		const normalizedNetworks: string[] = [];
 		for (const network of networks) {
 			try {
-				normalizeNetwork(network);
+				normalizedNetworks.push(normalizeNetwork(network));
 			} catch {
 				context.addIssue({ code: z.ZodIssueCode.custom, message: `Unsupported network: ${network}` });
 			}
 		}
+
+		return normalizedNetworks.length === networks.length ? normalizedNetworks.join(',') : z.NEVER;
 	})
-	.transform((value) =>
-		value
-			.split(',')
-			.map((network) => normalizeNetwork(network.trim()))
-			.join(',')
-	)
 	.describe("Comma-separated supported networks (for example, 'sei,1328' or '0x531,sei-testnet').");
 
 /**


### PR DESCRIPTION
## Summary
- validate and normalize `compare_networks` inputs in a single Zod transform
- stop invalid transforms with `z.NEVER` so malformed networks return validation errors instead of internal failures

## Test plan
- [x] `bun run --cwd packages/mcp-server test`
- [x] `bun run typecheck`
- [x] `bun run --cwd packages/mcp-server build`
- [x] `bunx biome check packages/mcp-server/src/core/prompts.ts`

Made with [Cursor](https://cursor.com)