### PR TITLE
ci: keep the create-sei smoke green on Version Packages branches

### DIFF
--- a/packages/create-sei/scripts/pending-changesets.ts
+++ b/packages/create-sei/scripts/pending-changesets.ts
@@ -1,0 +1,7 @@
+/**
+ * `.changeset` stores `config.json` and `README.md` next to the changesets themselves, so
+ * only the remaining markdown entries describe releases that Changesets has yet to consume.
+ */
+export function hasPendingChangesets(changesetDirectoryEntries: string[]): boolean {
+	return changesetDirectoryEntries.some((entry) => entry.endsWith('.md') && entry !== 'README.md');
+}

--- a/packages/create-sei/scripts/smoke-generated-app.ts
+++ b/packages/create-sei/scripts/smoke-generated-app.ts
@@ -3,10 +3,12 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { BRAND_ASSET_HASHES } from '../brand-assets';
+import { hasPendingChangesets } from './pending-changesets';
 import { type PrecompilesSource, type PrecompilesSourceSelection, type RequestedPrecompilesSource, selectPrecompilesSource } from './select-precompiles-source';
 
 const packageRoot = path.resolve(import.meta.dir, '..');
 const repositoryRoot = path.resolve(packageRoot, '../..');
+const changesetRoot = path.join(repositoryRoot, '.changeset');
 const precompilesRoot = path.join(repositoryRoot, 'packages/precompiles');
 const cliPath = path.join(packageRoot, 'dist/main.js');
 const templateManifestPath = path.join(packageRoot, 'templates/next-template/package.json');
@@ -88,6 +90,26 @@ async function pathExists(target: string): Promise<boolean> {
 		.catch(() => false);
 }
 
+async function computePendingReleasePlan(tempRoot: string): Promise<ReleasePlan> {
+	// A Version Packages branch consumes every changeset while it writes the bumped manifests
+	// this smoke test exists to validate, and `changeset status` rejects that state because the
+	// branch changes packages without a changeset. Only require a status report while changesets
+	// are still waiting to be released.
+	const changesetsPending = hasPendingChangesets(await fs.readdir(changesetRoot));
+	const releasePlanPath = path.join(tempRoot, 'changeset-status.json');
+	const exitCode = await run(
+		'Compute pending release metadata',
+		[process.execPath, 'run', 'changeset', 'status', '--output', releasePlanPath],
+		repositoryRoot,
+		changesetsPending
+	);
+	if (exitCode !== 0) {
+		console.log('Every changeset has already been consumed, so the error above is expected and no release is pending.');
+		return { releases: [] };
+	}
+	return JSON.parse(await fs.readFile(releasePlanPath, 'utf8')) as ReleasePlan;
+}
+
 async function resolvePrecompilesTarget(tempRoot: string): Promise<PrecompilesTarget> {
 	const templateManifest = JSON.parse(await fs.readFile(templateManifestPath, 'utf8')) as {
 		dependencies?: Record<string, string>;
@@ -97,9 +119,7 @@ async function resolvePrecompilesTarget(tempRoot: string): Promise<PrecompilesTa
 		throw new Error('The template must pin @sei-js/precompiles to one exact version.');
 	}
 
-	const releasePlanPath = path.join(tempRoot, 'changeset-status.json');
-	await run('Compute pending release metadata', [process.execPath, 'run', 'changeset', 'status', '--output', releasePlanPath], repositoryRoot);
-	const releasePlan = JSON.parse(await fs.readFile(releasePlanPath, 'utf8')) as ReleasePlan;
+	const releasePlan = await computePendingReleasePlan(tempRoot);
 	const pendingRelease = releasePlan.releases.find((release) => release.name === '@sei-js/precompiles');
 	const currentManifest = JSON.parse(await fs.readFile(path.join(precompilesRoot, 'package.json'), 'utf8')) as {
 		version: string;

--- a/packages/create-sei/src/main.test.ts
+++ b/packages/create-sei/src/main.test.ts
@@ -4,6 +4,7 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { BRAND_ASSET_HASHES } from '../brand-assets';
+import { hasPendingChangesets } from '../scripts/pending-changesets';
 import { selectPrecompilesSource } from '../scripts/select-precompiles-source';
 import { SEI_NEUTRAL_RAMP } from '../templates/next-template/src/theme';
 
@@ -80,6 +81,16 @@ describe('precompiles source selection', () => {
 		await expect(
 			selectPrecompilesSource({ currentVersion: '3.0.0', pendingVersion: '3.1.0', requestedSource: 'auto', targetVersion: '3.0.0' }, async () => false)
 		).rejects.toThrow('neither a matching local source nor the exact npm release is available');
+	});
+});
+
+describe('pending changeset detection', () => {
+	test('counts changeset markdown as pending', () => {
+		expect(hasPendingChangesets(['README.md', 'config.json', 'fix-create-sei-scaffold.md'])).toBe(true);
+	});
+
+	test('treats a versioned changeset folder as consumed', () => {
+		expect(hasPendingChangesets(['README.md', 'config.json'])).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Summary

The `Generated apps (auto)` check fails on every Version Packages release PR ([run on #339](https://github.com/sei-protocol/sei-js/actions/runs/32648753536/job/97217037755)). The release smoke calls `changeset status --output` to learn which version `@sei-js/precompiles` will publish as, but `changeset status` doubles as a lint: when a branch changes packages without adding a changeset it prints

```
🦋  error Some packages have been changed but no changesets were found.
```

and calls `process.exit(1)` *before* writing the `--output` file. A Version Packages branch is precisely that state — Changesets consumes every changeset while it writes the bumped manifests — so the smoke died at `Compute pending release metadata` and never reached the versions it exists to validate.

The script already knows how to handle a versioned branch: `selectPrecompilesSource` has a `current-manifest` basis for exactly this case. It just could not get there.

- Only treat the status report as mandatory while changesets are still waiting to be released; otherwise the consumed state resolves to an empty release plan.
- `changeset status` still runs unconditionally, and its output stays authoritative whenever it succeeds, so genuine failures (malformed changesets, unknown packages) remain fatal while changesets are pending.
- No changeset added: this touches only the CI harness, which is not part of the published `dist` (same as #338).

## Test plan

- [x] Reproduced the failure locally in a throwaway worktree: ran `changeset version` on top of `main` to mirror the release PR (`@sei-js/precompiles` 2.1.3 → 3.0.0, `.changeset` reduced to `README.md` + `config.json`), then confirmed `changeset status --output` exits 1 and writes no file.
- [x] Ran the full smoke against that simulated release state: it now selects the `current-manifest` basis, packs `@sei-js/precompiles@3.0.0` without retagging, and passes both variants through install, audit, Biome, the Next production build, and the runtime/brand-asset probes — `create-sei local smoke passed for base and precompiles variants at @sei-js/precompiles@3.0.0`.
- [x] Confirmed the pre-release path is unchanged on `main`, where `changeset status` still succeeds and reports the pending `@sei-js/precompiles@3.0.0` bump that the template pins.
- [x] `bun run check` and `bun test --isolate src` in `packages/create-sei` (17 pass), including two new tests covering the `.changeset` scan.

Made with [Cursor](https://cursor.com)